### PR TITLE
add tpAto field

### DIFF
--- a/NFe.Classes/Informacoes/Observacoes/procRef.cs
+++ b/NFe.Classes/Informacoes/Observacoes/procRef.cs
@@ -43,5 +43,16 @@ namespace NFe.Classes.Informacoes.Observacoes
         ///     Z12 - Indicador da origem do processo
         /// </summary>
         public IndicadorProcesso indProc { get; set; }
+
+        /// <summary>
+        ///     Z13 - Tipo do ato concessório 
+        /// </summary>
+        public TipoAtoConcessorio? tpAto { get; set; }
+
+        public bool ShouldSerializetpAto()
+        {
+            return tpAto.HasValue;
+        }
+
     }
 }

--- a/NFe.Classes/Informacoes/Observacoes/procRefTipos.cs
+++ b/NFe.Classes/Informacoes/Observacoes/procRefTipos.cs
@@ -43,10 +43,22 @@ namespace NFe.Classes.Informacoes.Observacoes
     /// </summary>
     public enum IndicadorProcesso
     {
-        [XmlEnum("0")] ipSEFAZ,
-        [XmlEnum("1")] ipJusticaFederal,
-        [XmlEnum("2")] ipJusticaEstadual,
-        [XmlEnum("3")] ipSecexRFB,
-        [XmlEnum("9")] ipOutros
+        [XmlEnum("0")] ipSEFAZ = 0,
+        [XmlEnum("1")] ipJusticaFederal = 1,
+        [XmlEnum("2")] ipJusticaEstadual = 2,
+        [XmlEnum("3")] ipSecexRFB = 3,
+        [XmlEnum("9")] ipOutros= 9
+    }
+
+    /// <summary>
+    ///     <para>08=Termo de Acordo;</para>
+    ///     <para>10=Regime Especial;</para>
+    ///     <para>12=Autorização específica;</para>
+    /// </summary>
+    public enum TipoAtoConcessorio
+    {
+        [XmlEnum("8")] termoAcordo = 8,
+        [XmlEnum("10")] regimeEspecial = 10,
+        [XmlEnum("12")] autorizacaoEspecifica = 12
     }
 }

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -1611,7 +1611,7 @@ namespace NFe.Servicos
                 {
                     var dadosEnvio = new XmlDocument();
                     dadosEnvio.LoadXml(xmlEnvio);
-                    retorno = ws.Execute(dadosEnvio);
+                    retorno = ws.Execute(dadosEnvio.FirstChild);
                 }
             }
             catch (WebException ex)


### PR DESCRIPTION
Foi adicionado o campo "tpAto"no grupo Processo Referenciado a fim de que o cliente possa enviar essa informação na integração da nota, sendo assim a alteração ocorreu em todo o fluxo da nota, desde a API até a geração do xml.

Nome do campo a ser utilizado na integração da nota: ConcessionActType (Tipo do Ato Concessório).

O grupo Processo Referenciado já possuí 2 campos, sendo que o tpAto é o terceiro campo que passou a compor o grupo e é o único não obrigatório caso o grupo seja preenchido, ou seja, os outros dois campos são obrigatórios caso o grupo seja informado na nota pois este não é obrigatório.

Foi necessário realizar alterações na lib Zeus, sendo assim é importante a atualização da lib no projeto.