### PR TITLE
Update infProt.cs

### DIFF
--- a/NFe.Classes/Protocolo/infProt.cs
+++ b/NFe.Classes/Protocolo/infProt.cs
@@ -96,6 +96,16 @@ namespace NFe.Classes.Protocolo
         ///     PR12 - Descrição literal do status da resposta.
         /// </summary>
         public string xMotivo { get; set; }
+        
+        /// <summary>
+        /// PR14 - Código da Mensagem.
+        /// </summary>
+        public int cMsg { get; set; }
+
+        /// <summary>
+        /// PR15 - Mensagem da SEFAZ para o emissor.
+        /// </summary>
+        public string xMsg { get; set; }
 
         /// <summary>
         ///     PR13 - Assinatura XML do grupo identificado pelo atributo “Id”


### PR DESCRIPTION
Os campos cMsg e xMsg são de uso exclusivo da SEFAZ.

Através desses campos, a SEFAZ pode encaminhar mensagens para o contribuinte, sendo assim, algumas notas podem receber essa informação e então temos que tratá-los para que as consultas sigam o fluxo normal qual esses campos existirem.