### PR TITLE
Allow proxy on ConsultaCadastro4 webservice

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPI.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPI.cs
@@ -62,7 +62,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O06 - Código de Enquadramento Legal do IPI
         /// </summary>
-        public int cEnq { get; set; }
+        public string cEnq { get; set; }
 
         /// <summary>
         ///     O07 (IPITrib) - Grupo do CST 00, 49, 50 e 99

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -162,7 +162,7 @@ namespace NFe.Servicos
             return new NfeAutorizacao(url, _certificado, _cFgServico.TimeOut);
         }
 
-        private INfeServico CriarServico(ServicoNFe servico, string versaoServico)
+        private INfeServico CriarServico(ServicoNFe servico, string versaoServico, string proxyAddress = null)
         {
             var url = Enderecador.ObterUrlServico(servico, _cFgServico);
 
@@ -269,7 +269,7 @@ namespace NFe.Servicos
                     }
 
                     if (_cFgServico.VersaoNfeConsultaCadastro == VersaoServico.ve400)
-                        return new CadConsultaCadastro4(url, _certificado, _cFgServico.TimeOut);
+                        return new CadConsultaCadastro4(url, _certificado, _cFgServico.TimeOut, proxyAddress);
 
                     return new Wsdl.ConsultaCadastro.DEMAIS_UFs.CadConsultaCadastro2(url, _certificado,
                         _cFgServico.TimeOut);
@@ -287,7 +287,7 @@ namespace NFe.Servicos
             }
         }
 
-        private INfeServico CriarServico(ServicoNFe servico)
+        private INfeServico CriarServico(ServicoNFe servico, string proxyAddress = null)
         {
             var url = Enderecador.ObterUrlServico(servico, _cFgServico);
 
@@ -387,7 +387,7 @@ namespace NFe.Servicos
                 case ServicoNFe.RecepcaoEventoEpec: return new RecepcaoEPEC(url, _certificado, _cFgServico.TimeOut);
 
                 case ServicoNFe.NfeConsultaCadastro:
-                    return new CadConsultaCadastro4(url, _certificado, _cFgServico.TimeOut);
+                    return new CadConsultaCadastro4(url, _certificado, _cFgServico.TimeOut, proxyAddress);
 
                 case ServicoNFe.NfeDownloadNF: return new NfeDownloadNF(url, _certificado, _cFgServico.TimeOut);
 
@@ -1118,13 +1118,13 @@ namespace NFe.Servicos
         /// <param name="documento">Documento a ser consultado</param>
         /// <returns>Retorna um objeto da classe RetornoNfeConsultaCadastro com o retorno do serviço NfeConsultaCadastro</returns>
         public async Task<RetornoNfeConsultaCadastro> NfeConsultaCadastroAsync(string uf,
-            ConsultaCadastroTipoDocumento tipoDocumento, string documento)
+            ConsultaCadastroTipoDocumento tipoDocumento, string documento, string proxyAddress = null)
         {
             var versaoServico =
                 ServicoNFe.NfeConsultaCadastro.VersaoServicoParaString(_cFgServico.VersaoNfeConsultaCadastro,
                     _cFgServico.cUF);
 
-            var ws = CriarServico(ServicoNFe.NfeConsultaCadastro);
+            var ws = CriarServico(ServicoNFe.NfeConsultaCadastro, proxyAddress);
 
             if (_cFgServico.VersaoNfeConsultaCadastro != VersaoServico.ve400)
                 ws.nfeCabecMsg = new nfeCabecMsg

--- a/NFe.Wsdl/ConsultaCadastro/DEMAIS_UFs/CadConsultaCadastro4.cs
+++ b/NFe.Wsdl/ConsultaCadastro/DEMAIS_UFs/CadConsultaCadastro4.cs
@@ -9,7 +9,7 @@ namespace NFe.Wsdl.ConsultaCadastro.DEMAIS_UFs
 {
     public class CadConsultaCadastro4 : CadConsultaCadastro4Soap12Client, INfeServico
     {
-        public CadConsultaCadastro4(string url, X509Certificate certificado, int timeOut) : base(url)
+        public CadConsultaCadastro4(string url, X509Certificate certificado, int timeOut, string proxyAddress = null) : base(url, proxyAddress)
         {
             ClientCredentials.ClientCertificate.Certificate = (X509Certificate2)certificado;
 
@@ -77,7 +77,7 @@ namespace NFe.Wsdl.ConsultaCadastro.DEMAIS_UFs
 
     public class CadConsultaCadastro4Soap12Client : SoapBindingClient<CadConsultaCadastro4Soap12>
     {
-        public CadConsultaCadastro4Soap12Client(string endpointAddressUri) : base(endpointAddressUri) { }
+        public CadConsultaCadastro4Soap12Client(string endpointAddressUri, string proxyAddress) : base(endpointAddressUri, proxyAddress) { }
 
         public Task<consultaCadastro4Response> consultaCadastroAsync(XmlNode nfeDadosMsg)
         {

--- a/NFe.Wsdl/ConsultaCadastro/DEMAIS_UFs/CadConsultaCadastro4.cs
+++ b/NFe.Wsdl/ConsultaCadastro/DEMAIS_UFs/CadConsultaCadastro4.cs
@@ -16,8 +16,8 @@ namespace NFe.Wsdl.ConsultaCadastro.DEMAIS_UFs
             if (proxyAddress != null)
             {
                 var proxyAddressSplitted = proxyAddress.Split(':');
-                ClientCredentials.UserName.UserName = proxyAddressSplitted.GetValue(3).ToString();
-                ClientCredentials.UserName.Password = proxyAddressSplitted.GetValue(4).ToString();
+                ClientCredentials.UserName.UserName = proxyAddressSplitted.GetValue(2).ToString();
+                ClientCredentials.UserName.Password = proxyAddressSplitted.GetValue(3).ToString();
             }
         }
 

--- a/NFe.Wsdl/ConsultaCadastro/DEMAIS_UFs/CadConsultaCadastro4.cs
+++ b/NFe.Wsdl/ConsultaCadastro/DEMAIS_UFs/CadConsultaCadastro4.cs
@@ -12,6 +12,13 @@ namespace NFe.Wsdl.ConsultaCadastro.DEMAIS_UFs
         public CadConsultaCadastro4(string url, X509Certificate certificado, int timeOut) : base(url)
         {
             ClientCredentials.ClientCertificate.Certificate = (X509Certificate2)certificado;
+
+            if (proxyAddress != null)
+            {
+                var proxyAddressSplitted = proxyAddress.Split(':');
+                ClientCredentials.UserName.UserName = proxyAddressSplitted.GetValue(3).ToString();
+                ClientCredentials.UserName.Password = proxyAddressSplitted.GetValue(4).ToString();
+            }
         }
 
         public nfeCabecMsg nfeCabecMsg { get; set; }

--- a/NFe.Wsdl/SoapBindingClient.cs
+++ b/NFe.Wsdl/SoapBindingClient.cs
@@ -1,4 +1,5 @@
-﻿using System.ServiceModel;
+﻿using System;
+using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Text;
 
@@ -14,5 +15,33 @@ namespace NFe.Wsdl
                 {
                     RequireClientCertificate = true, MaxReceivedMessageSize = int.MaxValue
                 }), new EndpointAddress(endpointAddressUri)) { }
+
+        public SoapBindingClient(string endpointAddressUri, string proxyAddress) : base(GetCustomBidingWithProxy(proxyAddress), new EndpointAddress(endpointAddressUri))
+        { }
+
+        private static Binding GetCustomBidingWithProxy(string proxyAddress)
+        {
+            var textMessage = new TextMessageEncodingBindingElement(
+                    MessageVersion.CreateVersion(EnvelopeVersion.Soap12, AddressingVersion.None), Encoding.UTF8);
+
+            var httpsTransport = new HttpsTransportBindingElement
+            {
+                RequireClientCertificate = true,
+                MaxReceivedMessageSize = int.MaxValue
+            };
+
+            if (proxyAddress != null)
+            {
+                var proxySplitted = proxyAddress.Split(':');
+
+                httpsTransport.BypassProxyOnLocal = false;
+                httpsTransport.ProxyAddress = new Uri($"http://{proxySplitted.GetValue(0)}:{proxySplitted.GetValue(1)}");
+                httpsTransport.MaxBufferSize = int.MaxValue;
+                httpsTransport.UseDefaultWebProxy = false;
+                httpsTransport.ProxyAuthenticationScheme = System.Net.AuthenticationSchemes.Basic;
+            }
+
+            return new CustomBinding(textMessage, httpsTransport);
+        }
     }
 }


### PR DESCRIPTION
Permite que o webservice soap seja consultado de diferentes origens (IPs).
Afeta apenas o ConsultaCadastro4 (inscrição estadual)