### PR TITLE
#18262 - do not generate cMsg tag when value is null

### DIFF
--- a/NFe.Classes/Protocolo/infProt.cs
+++ b/NFe.Classes/Protocolo/infProt.cs
@@ -100,7 +100,7 @@ namespace NFe.Classes.Protocolo
         /// <summary>
         /// PR14 - Código da Mensagem.
         /// </summary>
-        public int cMsg { get; set; }
+        public int? cMsg { get; set; }
 
         /// <summary>
         /// PR15 - Mensagem da SEFAZ para o emissor.
@@ -112,5 +112,10 @@ namespace NFe.Classes.Protocolo
         ///     A decisão de assinar a mensagem fica a critério da UF interessada.
         /// </summary>
         public Signature Signature { get; set; }
+
+        public bool ShouldSerializecMsg()
+        {
+            return cMsg.HasValue;
+        }
     }
 }


### PR DESCRIPTION
Tag "cMsg" do protocolo de autorização está sendo gerada mesmo com valor nulo:

<protNFe versao="4.00">
<infProt Id="Id141240582133371">
<tpAmb>1</tpAmb>
<verAplic>PR-v4_4_54</verAplic>
<chNFe>41240445199721000100650020000041631883355884</chNFe>
<dhRecbto>2024-04-16T22:42:53-03:00</dhRecbto>
<nProt>141240582133371</nProt>
<digVal>/RLFZBajS/VDF+emNK3RUzccNb0=</digVal>
<cStat>100</cStat>
<xMotivo>Autorizado o uso da NF-e</xMotivo>
<cMsg>0</cMsg>
</infProt>
</protNFe>

Não gerar a tag "cMsg" quando o valor for nulo:

<protNFe versao="4.00">
<infProt Id="Id135240000705117">
<tpAmb>2</tpAmb>
<verAplic>SP_NFCE_PL_009_V400</verAplic>
<chNFe>35240401385258000116650010000002841079700659</chNFe>
<dhRecbto>2024-04-17T17:58:51-03:00</dhRecbto>
<nProt>135240000705117</nProt>
<digVal>gGrRvh232R1slSPGTMMSOt54Lc0=</digVal>
<cStat>100</cStat>
<xMotivo>Autorizado o uso da NF-e</xMotivo>
</infProt>
</protNFe>
