### PR TITLE
Increase rounding precision for pDif property to 4 decimals

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
@@ -112,8 +112,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pDif
         {
-            get { return _pDif.Arredondar(2); }
-            set { _pDif = value.Arredondar(2); }
+            get { return _pDif.Arredondar(4); }
+            set { _pDif = value.Arredondar(4); }
         }
 
         /// <summary>


### PR DESCRIPTION
Updated the `pDif` property in `ICMS51.cs` to round values to 4 decimal places instead of 2.