### PR TITLE
Add ShouldSerialize methods for nullable ICMS fields

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/Tipos/IBSCBSTipos.cs
@@ -85,7 +85,14 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.Tipos
         [Description("Alíquota reduzida")]
         [XmlEnum("200")]
         Cst200,
-        
+
+        /// <summary>
+        ///     210 - Crédito Presumido Operacional
+        /// </summary>
+        [Description("Crédito Presumido Operacional")]
+        [XmlEnum("210")]
+        Cst210,
+
         /// <summary>
         ///     220 - Alíquota fixa
         /// </summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
@@ -123,11 +123,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             set { _vICMSMonoDif = value.Arredondar(2); }
         }
 
-        public bool ShouldSerializevICMSMonoDif()
-        {
-            return vICMSMonoDif.HasValue;
-        }
-
         /// <summary>
         ///     N39 - Valor do ICMS próprio devido
         /// </summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
@@ -68,11 +68,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             set { _qBCMono = value.Arredondar(4); }
         }
 
-        public bool ShouldSerializeqBCMono()
-        {
-            return qBCMono.HasValue;
-        }
-
         /// <summary>
         ///     N38 - Alíquota adRem do imposto
         /// </summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
@@ -67,10 +67,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _qBCMono.Arredondar(4); }
             set { _qBCMono = value.Arredondar(4); }
         }
-        public bool ShouldSerializeqBCMono()
-        {
-            return qBCMono.HasValue;
-        }
 
         public bool ShouldSerializeqBCMono()
         {
@@ -85,10 +81,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         {
             get { return _adRemICMS.Arredondar(4); }
             set { _adRemICMS = value.Arredondar(4); }
-        }
-        public bool ShouldSerializeadRemICMS()
-        {
-            return adRemICMS.HasValue;
         }
 
         public bool ShouldSerializeadRemICMS()
@@ -105,10 +97,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _vICMSMonoOp.Arredondar(2); }
             set { _vICMSMonoOp = value.Arredondar(2); }
         }
-        public bool ShouldSerializevICMSMonoOp()
-        {
-            return vICMSMonoOp.HasValue;
-        }
 
         public bool ShouldSerializevICMSMonoOp()
         {
@@ -123,10 +111,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         {
             get { return _pDif.Arredondar(4); }
             set { _pDif = value.Arredondar(4); }
-        }
-        public bool ShouldSerializepDif()
-        {
-            return pDif.HasValue;
         }
 
         public bool ShouldSerializepDif()
@@ -143,10 +127,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _vICMSMonoDif.Arredondar(2); }
             set { _vICMSMonoDif = value.Arredondar(2); }
         }
-        public bool ShouldSerializevICMSMonoDif()
-        {
-            return vICMSMonoDif.HasValue;
-        }
 
         public bool ShouldSerializevICMSMonoDif()
         {
@@ -162,6 +142,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _vICMSMono.Arredondar(2); }
             set { _vICMSMono = value.Arredondar(2); }
         }
+
         public bool ShouldSerializevICMSMono()
         {
             return vICMSMono.HasValue;
@@ -177,6 +158,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _qBCMonoDif.Arredondar(4); }
             set { _qBCMonoDif = value.Arredondar(4); }
         }
+
         public bool ShouldSerializeqBCMonoDif()
         {
             return qBCMonoDif.HasValue;
@@ -192,10 +174,10 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _adRemICMSDif.Arredondar(4); }
             set { _adRemICMSDif = value.Arredondar(4); }
         }
+
         public bool ShouldSerializeadRemICMSDif()
         {
             return adRemICMSDif.HasValue;
         }
-
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS53.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -72,6 +72,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             return qBCMono.HasValue;
         }
 
+        public bool ShouldSerializeqBCMono()
+        {
+            return qBCMono.HasValue;
+        }
+
         /// <summary>
         ///     N38 - Alíquota adRem do imposto
         /// </summary>
@@ -81,6 +86,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _adRemICMS.Arredondar(4); }
             set { _adRemICMS = value.Arredondar(4); }
         }
+        public bool ShouldSerializeadRemICMS()
+        {
+            return adRemICMS.HasValue;
+        }
+
         public bool ShouldSerializeadRemICMS()
         {
             return adRemICMS.HasValue;
@@ -100,6 +110,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             return vICMSMonoOp.HasValue;
         }
 
+        public bool ShouldSerializevICMSMonoOp()
+        {
+            return vICMSMonoOp.HasValue;
+        }
+
         /// <summary>
         ///     N42 - Percentual do diferimento
         /// </summary>
@@ -114,6 +129,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             return pDif.HasValue;
         }
 
+        public bool ShouldSerializepDif()
+        {
+            return pDif.HasValue;
+        }
+
         /// <summary>
         ///     N43 - Valor do ICMS diferido
         /// </summary>
@@ -123,6 +143,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _vICMSMonoDif.Arredondar(2); }
             set { _vICMSMonoDif = value.Arredondar(2); }
         }
+        public bool ShouldSerializevICMSMonoDif()
+        {
+            return vICMSMonoDif.HasValue;
+        }
+
         public bool ShouldSerializevICMSMonoDif()
         {
             return vICMSMonoDif.HasValue;

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS61.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS61.cs
@@ -93,5 +93,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             set { _vICMSMonoRet = value.Arredondar(2); }
         }
 
+        public bool ShouldSerializevICMSMonoRet()
+        {
+            return vICMSMonoRet.HasValue;
+        }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS61.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS61.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -76,6 +76,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         {
             get { return _adRemICMSRet.Arredondar(4); }
             set { _adRemICMSRet = value.Arredondar(4); }
+        }
+
+        public bool ShouldSerializeadRemICMSRet()
+        {
+            return adRemICMSRet.HasValue;
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/InfRespTec/infRespTec.cs
+++ b/NFe.Classes/Informacoes/InfRespTec/infRespTec.cs
@@ -1,6 +1,6 @@
 ﻿using System.Xml.Serialization;
 
-namespace Shared.NFe.Classes.Informacoes.InfRespTec
+namespace NFe.Classes.Informacoes.InfRespTec
 {
     public class infRespTec
     {

--- a/NFe.Classes/Informacoes/Intermediador/infIntermed.cs
+++ b/NFe.Classes/Informacoes/Intermediador/infIntermed.cs
@@ -1,4 +1,4 @@
-﻿namespace Shared.NFe.Classes.Informacoes.Intermediador
+﻿namespace NFe.Classes.Informacoes.Intermediador
 {
     public class infIntermed
     {

--- a/NFe.Classes/Informacoes/infNFe.cs
+++ b/NFe.Classes/Informacoes/infNFe.cs
@@ -43,8 +43,8 @@ using NFe.Classes.Informacoes.Observacoes;
 using NFe.Classes.Informacoes.Pagamento;
 using NFe.Classes.Informacoes.Total;
 using NFe.Classes.Informacoes.Transporte;
-using Shared.NFe.Classes.Informacoes.InfRespTec;
-using Shared.NFe.Classes.Informacoes.Intermediador;
+using NFe.Classes.Informacoes.InfRespTec;
+using NFe.Classes.Informacoes.Intermediador;
 
 namespace NFe.Classes.Informacoes
 {


### PR DESCRIPTION
Refactor ICMS serialization and update NFe namespaces

Simplified ShouldSerialize methods in ICMS53 and ICMS61 to directly check HasValue, ensuring nullable properties are only serialized when set. Added missing ShouldSerialize methods for new properties. Updated namespaces in infRespTec and infIntermed to NFe.Classes and adjusted related using statements for consistency. Improves code clarity and standardization.

Related PR:  
https://dev.azure.com/nfe-io/Main/_git/nfeio-product-invoice/pullrequest/5500
The changes in this PR directly impact the DFe.App.ProductInvoice project. Therefore, both PRs must be approved before deployment.