### PR TITLE
feat(rtc): adicionar método do evento 112150 e 7 XSDs da NT 2025.002-RTC

### DIFF
--- a/NFe.AppTeste/NFe.AppTeste.csproj
+++ b/NFe.AppTeste/NFe.AppTeste.csproj
@@ -216,6 +216,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Schemas\e110001_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Schemas\e110110_v1.00.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -244,6 +248,26 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Schemas\e112110_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Schemas\e112120_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Schemas\e112130_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Schemas\e112140_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Schemas\e112150_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Schemas\e210200_v1.00.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -257,6 +281,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Schemas\e210240_v1.00.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Schemas\e211120_v1.00.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/NFe.AppTeste/Schemas/e110001_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e110001_v1.00.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Cancelamento de evento</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Informar “Cancelamento de Evento"</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Cancelamento de Evento"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpEventoAut">
+					<xs:annotation>
+						<xs:documentation>Código do evento autorizado a ser cancelado</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="112110"/>
+							<xs:enumeration value="112120"/>
+							<xs:enumeration value="112130"/>
+							<xs:enumeration value="112140"/>
+							<xs:enumeration value="112150"/>
+							<xs:enumeration value="211110"/>
+							<xs:enumeration value="211120"/>
+							<xs:enumeration value="211124"/>
+							<xs:enumeration value="211128"/>
+							<xs:enumeration value="211130"/>
+							<xs:enumeration value="211140"/>
+							<xs:enumeration value="211150"/>
+							<xs:enumeration value="212110"/>
+							<xs:enumeration value="212120"/>
+							<xs:enumeration value="412120"/>
+							<xs:enumeration value="412130"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProtEvento" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Informar o número do Protocolo de Autorização do Evento a ser cancelado</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento </xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/NFe.AppTeste/Schemas/e112110_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e112110_v1.00.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Evento de Informação de efetivo pagamento integral para liberar crédito presumido do adquirente</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento de Informação de efetivo pagamento integral para liberar crédito presumido do adquirente</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Informação de efetivo pagamento integral para liberar crédito presumido do adquirente"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpAutor">
+					<xs:annotation>
+						<xs:documentation>Informar 1=Empresa emitente
+													Valores: 1=Empresa Emitente, 2=Empresa destinatária; 3=Empresa; 5=Fisco;6=RFB; 9=Outros Órgãos;
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="indQuitacao">
+					<xs:annotation>
+						<xs:documentation>Indicador de efetiva quitação do pagamento integral referente a NFe referenciada. 
+							Valor deve ser igual a "1"
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento </xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/NFe.AppTeste/Schemas/e112120_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e112120_v1.00.xsd
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Evento de Importação em ALC/ZFM não convertida em isenção</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do evento: "Importação em ALC/ZFM não convertida em isenção"</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Importação em ALC/ZFM não convertida em isenção"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpAutor">
+					<xs:annotation>
+						<xs:documentation>Informar 1=Empresa emitente
+													Valores: 1=Empresa Emitente, 2=Empresa destinatária; 3=Empresa; 5=Fisco;6=RFB; 9=Outros Órgãos;
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gConsumo" maxOccurs="990">
+					<xs:annotation>
+						<xs:documentation>Informações de itens integrados ao ativo imobilizado</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="vIBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS correspondente à quantidade que não atendeu aos requisitos para a conversão em isenção</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vCBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do CBS correspondente à quantidade que não atendeu aos requisitos para a conversão em isenção</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gControleEstoque">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="qtde" type="TDec_1104">
+											<xs:annotation>
+												<xs:documentation>Informar a quantidade que não atendeu os requisitos para a conversão em isenção</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="unidade">
+											<xs:annotation>
+												<xs:documentation>Informar a unidade relativa ao campo gConsumo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="6"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="nItem" type="TnItem" use="required">
+							<xs:annotation>
+								<xs:documentation>Corresponde ao atributo “nItem” do elemento “det” da NF-e de importação </xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento </xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+		<xs:unique name="pk_nItem">
+			<xs:selector xpath="./*"/>
+			<xs:field xpath="@nItem"/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/NFe.AppTeste/Schemas/e112130_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e112130_v1.00.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Evento de Perecimento, perda, roubo ou furto durante o transporte contratado pelo fornecedor</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do evento: "Perecimento, perda, roubo ou furto durante o transporte contratado pelo fornecedor""</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Perecimento, perda, roubo ou furto durante o transporte contratado pelo fornecedor"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpAutor">
+					<xs:annotation>
+						<xs:documentation>Informar 1=Empresa emitente
+													Valores: 1=Empresa Emitente, 2=Empresa destinatária; 3=Empresa; 5=Fisco;6=RFB; 9=Outros Órgãos;
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gPerecimento" maxOccurs="990">
+					<xs:annotation>
+						<xs:documentation>Informações por item da Nota de Fornecimento</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="vIBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS na Nota de Fornecimento correspondente à quantidade que foi objeto de roubo, perda, furto ou perecimento.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vCBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor da CBS na Nota de Fornecimento correspondente à quantidade que foi objeto de roubo, perda, furto ou perecimento.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gControleEstoque">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="qPerecimento" type="TDec_1104">
+											<xs:annotation>
+												<xs:documentation>Informar a quantidade que foi objeto de roubo, perda, furto ou perecimento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="uPerecimento">
+											<xs:annotation>
+												<xs:documentation>Informar a unidade relativa ao campo qPerecimento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="6"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:sequence>
+											<xs:element name="vIBS" type="TDec_1302">
+												<xs:annotation>
+													<xs:documentation>Valor do crédito IBS referente às aquisições a ser estornado correspondente à quantidade que foi objeto de roubo, perda, furto ou perecimento</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="vCBS" type="TDec_1302">
+												<xs:annotation>
+													<xs:documentation>Valor do crédito CBS referente às aquisições a ser estornado correspondente à quantidade que foi objeto de roubo, perda, furto ou perecimento</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:sequence>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="nItem" type="TnItem" use="required">
+							<xs:annotation>
+								<xs:documentation>Corresponde ao atributo “nItem” do elemento “det” da NF-e de importação </xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento </xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+		<xs:unique name="pk_nItem">
+			<xs:selector xpath="./*"/>
+			<xs:field xpath="@nItem"/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/NFe.AppTeste/Schemas/e112140_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e112140_v1.00.xsd
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Evento de Fornecimento não realizado com pagamento antecipado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>"Descrição do evento: "Fornecimento não realizado com pagamento antecipado"</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Fornecimento não realizado com pagamento antecipado"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpAutor">
+					<xs:annotation>
+						<xs:documentation>Informar 1=Empresa emitente
+													Valores: 1=Empresa Emitente, 2=Empresa destinatária; 3=Empresa; 5=Fisco;6=RFB; 9=Outros Órgãos;
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gItemNaoFornecido" maxOccurs="990">
+					<xs:annotation>
+						<xs:documentation>Informações por item da Nota de Fornecimento</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="vIBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS na nota de débito de pagamento antecipado correspondente à quantidade que não foi fornecida</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vCBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor da CBS na nota de débito de pagamento antecipado correspondente à quantidade que não foi fornecida.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gControleEstoque">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="qNaoFornecida" type="TDec_1104">
+											<xs:annotation>
+												<xs:documentation>Informar a quantidade que não foi fornecida e teve o imposto antecipado</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="uNaoFornecida">
+											<xs:annotation>
+												<xs:documentation>Informar a unidade relativa ao campo qNaoFornecida</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="6"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="nItem" type="TnItem" use="required">
+							<xs:annotation>
+								<xs:documentation>Corresponde ao atributo “nItem” do elemento “det” da NF-e de importação </xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento </xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+		<xs:unique name="pk_nItem">
+			<xs:selector xpath="./*"/>
+			<xs:field xpath="@nItem"/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/NFe.AppTeste/Schemas/e112150_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e112150_v1.00.xsd
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Evento de Atualização da Data de Previsão de Entrega</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do evento: "Atualização da Data de Previsão de Entrega"</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Atualização da Data de Previsão de Entrega"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpAutor">
+					<xs:annotation>
+						<xs:documentation>Informar 1=Empresa emitente
+													Valores: 1=Empresa Emitente, 2=Empresa destinatária; 3=Empresa; 5=Fisco;6=RFB; 9=Outros Órgãos;
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dPrevEntrega" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data da previsão de entrega ou disponibilização do bem.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento </xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/NFe.AppTeste/Schemas/e211120_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/e211120_v1.00.xsd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-software@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
+	<xs:element name="detEvento">
+		<xs:annotation>
+			<xs:documentation>Informações do Evento de Destinação de item para consumo pessoal</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento de Destinação de item para consumo pessoal</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Destinação de item para consumo pessoal"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="cOrgaoAutor" type="TCodUfIBGE">
+					<xs:annotation>
+						<xs:documentation>Código do Órgão Autor do Evento. Informar o Código da UF para este Evento.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpAutor">
+					<xs:annotation>
+						<xs:documentation>Caso NF-e de Importação, informar 1=Empresa Emitente.
+												Demais casos, informar 2=Empresa destinatária
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="verAplic" type="TVerAplic">
+					<xs:annotation>
+						<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gConsumo" maxOccurs="990">
+					<xs:annotation>
+						<xs:documentation>Informações por item da NF-e de Aquisição</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="vIBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS na nota de aquisição correspondente à quantidade destinada a uso e consumo pessoal</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vCBS" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor da CBS na nota de aquisição correspondente à quantidade destinada a uso e consumo pessoal</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gControleEstoque">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="qConsumo" type="TDec_1104">
+											<xs:annotation>
+												<xs:documentation>Informar a quantidade para consumo de pessoa física</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="uConsumo">
+											<xs:annotation>
+												<xs:documentation>Informar a unidade relativa ao campo gConsumo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="6"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="DFeReferenciado">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="chaveAcesso" type="TChNFe">
+											<xs:annotation>
+												<xs:documentation>Informar a chave da nota (NFe ou NFCe) emitida para o fornecimento nos casos em que a legislação obriga a emissão de documento fiscal.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="nItem" type="TnItem">
+											<xs:annotation>
+												<xs:documentation>Corresponde ao atributo “nItem” do elemento “det” do documento referenciado</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="nItem" type="TnItem" use="required">
+							<xs:annotation>
+								<xs:documentation>Corresponde ao atributo “nItem” do elemento “det” da NF-e de importação </xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="versao">
+				<xs:annotation>
+					<xs:documentation>Versão do leiaute do evento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="1.00"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+		<xs:unique name="pk_nItem">
+			<xs:selector xpath="./*"/>
+			<xs:field xpath="@nItem"/>
+		</xs:unique>
+	</xs:element>
+</xs:schema>

--- a/NFe.Classes/Servicos/Evento/detEvento.cs
+++ b/NFe.Classes/Servicos/Evento/detEvento.cs
@@ -421,6 +421,26 @@ namespace NFe.Classes.Servicos.Evento
 
         #endregion
 
+        #region Atualização da Data de Previsão de Entrega
+
+        /// <summary>
+        ///  P23 - Data da previsão de entrega ou disponibilização do bem. Formato: "AAAA-MM-DD".
+        /// </summary>
+        [XmlIgnore]
+        public DateTime? dPrevEntrega { get; set; }
+
+        /// <summary>
+        /// Proxy para dPrevEntrega no formato "AAAA-MM-DD" (somente data).
+        /// </summary>
+        [XmlElement("dPrevEntrega")]
+        public string ProxydPrevEntrega
+        {
+            get => dPrevEntrega.ParaDataString();
+            set => dPrevEntrega = DateTime.Parse(value);
+        }
+
+        #endregion
+
         #endregion
     }
 }

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -678,7 +678,8 @@ namespace NFe.Servicos
                 ServicoNFe.RecepcaoEventoImportacaoEmAlcZfmNaoConvertidaEmIsencao,
                 ServicoNFe.RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloAdquirente,
                 ServicoNFe.RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloFornecedor,
-                ServicoNFe.RecepcaoEventoFornecimentoNaoRealizadoComPagamentoAntecipado
+                ServicoNFe.RecepcaoEventoFornecimentoNaoRealizadoComPagamentoAntecipado,
+                ServicoNFe.RecepcaoEventoAtualizacaoDataPrevisaoDeEntrega
             };
 
             if (!listaEventos.Contains(servicoEvento))
@@ -2093,6 +2094,44 @@ namespace NFe.Servicos
 
             var detalhesEvento = ObterDetalhesEvento(versaoServicoRecepcaoString, versaoAplicativo, nfeTipoEvento, ufAutor, TipoAutor.taEmpresaEmitente);
             detalhesEvento.gItemNaoFornecido = informacoesPorItemDaNotaDePagamentoAntecipado;
+
+            var informacoesEventoEnv = ObterInformacoesEventoEnv(sequenciaEvento, chaveNFe, cpfCnpj, versaoServicoRecepcaoString, cOrgao: Estado.SVRS, dataHoraEvento, nfeTipoEvento, detalhesEvento);
+            var evento = ObterEvento(versaoServicoRecepcaoString, informacoesEventoEnv);
+
+            var retornoRecepcaoEvento = await EnviarEObterRetornoRecepcaoEvento(idLote, servicoNfe, deveAssinar: true, evento);
+
+            return retornoRecepcaoEvento;
+        }
+
+        /// <summary>
+        ///     Serviço destinado à recepção do evento RTC 112150 — Atualização da Data de Previsão de Entrega.
+        ///     Previsto na NT 2025.002-RTC, autoria do Emitente, NF-e modelo 55.
+        /// </summary>
+        /// <param name="idLote">Nº do lote</param>
+        /// <param name="sequenciaEvento">sequencia do evento</param>
+        /// <param name="cpfCnpj"></param>
+        /// <param name="chaveNFe"></param>
+        /// <param name="dataPrevistaEntrega">Data da previsão de entrega ou disponibilização do bem (formato "AAAA-MM-DD")</param>
+        /// <param name="ufAutor"></param>
+        /// <param name="versaoAplicativo"></param>
+        /// <param name="dataHoraEvento"></param>
+        /// <returns></returns>
+        public async Task<RetornoRecepcaoEvento> RecepcaoEventoAtualizacaoDaDataDePrevisaoDeEntrega(int idLote,
+                                                                                                   int sequenciaEvento,
+                                                                                                   string cpfCnpj,
+                                                                                                   string chaveNFe,
+                                                                                                   DateTime dataPrevistaEntrega,
+                                                                                                   Estado? ufAutor = null,
+                                                                                                   string versaoAplicativo = null,
+                                                                                                   DateTimeOffset? dataHoraEvento = null)
+        {
+            const ServicoNFe servicoNfe = ServicoNFe.RecepcaoEventoAtualizacaoDataPrevisaoDeEntrega;
+            const NFeTipoEvento nfeTipoEvento = NFeTipoEvento.TeNfeAtualizacaoDaDataDePrevisaoDeEntrega;
+            var versaoServicoRecepcao = _cFgServico.VersaoRecepcaoEventosDeApuracaoDoIbsECbs;
+            var versaoServicoRecepcaoString = servicoNfe.VersaoServicoParaString(versaoServicoRecepcao);
+
+            var detalhesEvento = ObterDetalhesEvento(versaoServicoRecepcaoString, versaoAplicativo, nfeTipoEvento, ufAutor, TipoAutor.taEmpresaEmitente);
+            detalhesEvento.dPrevEntrega = dataPrevistaEntrega;
 
             var informacoesEventoEnv = ObterInformacoesEventoEnv(sequenciaEvento, chaveNFe, cpfCnpj, versaoServicoRecepcaoString, cOrgao: Estado.SVRS, dataHoraEvento, nfeTipoEvento, detalhesEvento);
             var evento = ObterEvento(versaoServicoRecepcaoString, informacoesEventoEnv);


### PR DESCRIPTION
## Contexto

Este fork (`nfe/DFe.NET`) já contém suporte parcial aos eventos RTC da NT 2025.002-RTC, trazidos via cherry-pick anterior (`a04a2ee3 ajuste apps para reforma tributaria`). Faltava completar o **evento 112150 (Atualização da Data de Previsão de Entrega)** e os **7 schemas XSD** correspondentes — bloqueio para `nfe/dfetech-product-invoice-api#8` (preparação dos eventos RTC no consumer, status "Ready").

Sincronização **seletiva** com upstream — não merge dos 1906 commits do `ZeusAutomacao/DFe.NET` (que conflitariam com nossos 277 hotfixes de URL SEFAZ, NTs antecipadas, SVAN customizado, conversão sync→async).

## SHA de referência do upstream

Conteúdo derivado de [`ZeusAutomacao/DFe.NET@cfe8d802`](https://github.com/ZeusAutomacao/DFe.NET/commit/cfe8d802) (tag `2026.04.20.1711`).

## O que muda

### Commit `d8fc3a7b` — 7 schemas XSD

Em `NFe.AppTeste/Schemas/` (cópia byte-a-byte do upstream + entrada no `.csproj`):
- `e110001_v1.00.xsd` — Cancelamento de Evento RTC
- `e112110_v1.00.xsd` — Pagamento integral
- `e112120_v1.00.xsd` — ALC/ZFM não convertida em isenção
- `e112130_v1.00.xsd` — Perecimento transporte fornecedor
- `e112140_v1.00.xsd` — Fornecimento não realizado
- `e112150_v1.00.xsd` — Atualização Data Previsão Entrega
- `e211120_v1.00.xsd` — Consumo pessoal (NF-e Importação)

### Commit `2857e5dd` — campo `dPrevEntrega`

`NFe.Classes/Servicos/Evento/detEvento.cs`: nova propriedade `DateTime? dPrevEntrega` + proxy `ProxydPrevEntrega` serializado como `<dPrevEntrega>` formato `AAAA-MM-DD`. Idêntico ao upstream.

### Commit `b5254419` — método 112150 em `ServicosNFe`

Novo método público `RecepcaoEventoAtualizacaoDaDataDePrevisaoDeEntrega`, completando os 7 eventos RTC do escopo da issue. Adaptado do upstream para o padrão **assíncrono** do fork (`async Task<RetornoRecepcaoEvento>` + `await EnviarEObterRetornoRecepcaoEvento`), seguindo template idêntico aos 6 métodos RTC irmãos. Inclui o serviço no array `listaEventos` de `RecepcaoEventoAsync` para consistência.

## Garantias

- **Zero breaking changes**: adição pura. Nenhum método/enum/classe pré-existente foi renomeado ou teve assinatura alterada.
- **Zero alteração** nos 6 métodos RTC já presentes (110001, 112110, 112120, 112130, 112140, 211120).
- **Nenhum hotfix nosso** de URL SEFAZ tocado (`Enderecador`, `ServicosNFe.CriarServico`, `Validador`).

## Validações

| Validação | Resultado |
|---|---|
| `dotnet build NFe.Servicos -c Release` | ✅ 0 errors, warnings só pré-existentes |
| MSBuild solução completa Release | ✅ 0 errors, warnings só pré-existentes |
| `NFe.Testes` (legacy MSTest) | ✅ compila; vstest.console não disponível, sanity OK |
| `NFCe.Tests` | ⚠️ 1 falha pré-existente (path hardcoded `C:\Works\nfe\nfe-products-api\schemas`); reproduzido em `master`, não é regressão |
| Consumer `dfetech-product-invoice-api` build com submódulo neste SHA | ✅ 0 errors |
| `DFeTech.ProductInvoice.Tests` | ✅ 104/104 |
| `DFeTech.Taxes.Tests.Unit` | ✅ 43/43 |

## Não-objetivos (explícitos)

- Merge de outros commits do upstream
- Eventos RTC de autoria Destinatário/Sucessora/Fisco (excluídos pela D-001 da análise da issue)
- Ajustes em DANFE (NT §9 posterga)
- Bump do submódulo no consumer + cópia de XSDs para `nfeio-product-invoice/schemas/` — ficam para mudança separada após merge deste PR

## Referência

- Issue: `nfe/dfetech-product-invoice-api#8`
- Análise técnica: `openspec/changes/adicionar-eventos-rtc-faltantes/` (proposal, design, specs, tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)