### PR TITLE
feat(rtc): adiciona tpNFCredito=06 (Recusa Parcial) — Ajuste SINIEF 8/26

### DIFF
--- a/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
+++ b/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
@@ -620,7 +620,7 @@ namespace NFe.Classes.Informacoes.Identificacao.Tipos
         [XmlEnum("04")]
         ReducaoDeValores,
 
-        [Description("Transferência de crédito na sucessão;")]
+        [Description("Transferência de crédito na sucessão")]
         [XmlEnum("05")]
         TfCreditoSucessao,
 

--- a/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
+++ b/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
@@ -589,7 +589,7 @@ namespace NFe.Classes.Informacoes.Identificacao.Tipos
     ///     Tipo de Nota de Crédito
     ///     <para>01 - Multa e juros</para>
     ///     <para>02 - Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)</para>
-    ///     <para>03 - Retorno por recusa na entrega ou por não localização do destinatário na tentativa de entrega</para>
+    ///     <para>03 - Retorno por Recusa Total na Entrega ou Por Não Localização do Destinatário (Ajuste SINIEF 8/26)</para>
     ///     <para>04 - Redução de valores</para>
     ///     <para>05 - Transferência de crédito na sucessão</para>
     ///     <para>06 - Retorno por Recusa Parcial na Entrega (Ajuste SINIEF 8/26, vigência 2026-05-04)</para>
@@ -604,7 +604,15 @@ namespace NFe.Classes.Informacoes.Identificacao.Tipos
         [XmlEnum("02")]
         ApropriacaoDeCredito,
 
-        [Description("Retorno por recusa na entrega ou por não localização do destinatário na tentativa de entrega")]
+        /// <summary>
+        ///     03 - Retorno por Recusa Total na Entrega ou Por Não Localização do Destinatário.
+        ///     A partir do Ajuste SINIEF 8/26 (vigência 2026-05-04), este código contempla
+        ///     somente a recusa TOTAL e a não localização do destinatário; a recusa PARCIAL
+        ///     foi separada em <see cref="RetornoPorRecusaParcial"/> (código 06).
+        ///     O nome do membro <c>RetornoPorRecusaOuNaoLocalizacaoDoDestinatario</c> é
+        ///     mantido para preservar compatibilidade binária com consumidores existentes.
+        /// </summary>
+        [Description("Retorno por Recusa Total na Entrega ou Por Não Localização do Destinatário")]
         [XmlEnum("03")]
         RetornoPorRecusaOuNaoLocalizacaoDoDestinatario,
 

--- a/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
+++ b/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
@@ -591,29 +591,43 @@ namespace NFe.Classes.Informacoes.Identificacao.Tipos
     ///     <para>02 - Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)</para>
     ///     <para>03 - Retorno por recusa na entrega ou por não localização do destinatário na tentativa de entrega</para>
     ///     <para>04 - Redução de valores</para>
-    ///     <para>05 - Transferência de crédito na sucessão;</para>
+    ///     <para>05 - Transferência de crédito na sucessão</para>
+    ///     <para>06 - Retorno por Recusa Parcial na Entrega (Ajuste SINIEF 8/26, vigência 2026-05-04)</para>
     /// </summary>
     public enum TpNotaCredito
     {
         [Description("Multa e juros")]
         [XmlEnum("01")]
         MultaJuros,
-        
+
         [Description("Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)")]
         [XmlEnum("02")]
         ApropriacaoDeCredito,
-        
+
         [Description("Retorno por recusa na entrega ou por não localização do destinatário na tentativa de entrega")]
         [XmlEnum("03")]
         RetornoPorRecusaOuNaoLocalizacaoDoDestinatario,
-        
+
         [Description("Redução de valores")]
         [XmlEnum("04")]
         ReducaoDeValores,
-                
+
         [Description("Transferência de crédito na sucessão;")]
         [XmlEnum("05")]
-        TfCreditoSucessao
+        TfCreditoSucessao,
+
+        /// <summary>
+        ///     06 - Retorno por Recusa Parcial na Entrega.
+        ///     Introduzido pelo Ajuste SINIEF 8/26 (vigência 2026-05-04), que separa
+        ///     o antigo código 03 (recusa total + parcial + não localização) em:
+        ///     - 03 = Recusa Total ou Não Localização
+        ///     - 06 = Recusa Parcial (este novo valor)
+        ///     Quando utilizado, exige <c>DFeReferenciado</c> por item (referenciamento
+        ///     dos itens recusados na NF-e original).
+        /// </summary>
+        [Description("Retorno por Recusa Parcial na Entrega")]
+        [XmlEnum("06")]
+        RetornoPorRecusaParcial
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adiciona suporte ao **Ajuste SINIEF 8/26** (vigência **2026-05-04**) no enum `TpNotaCredito`:

- **`RetornoPorRecusaParcial = 6`** — novo membro do enum com `[XmlEnum("06")]`. O Ajuste 8/26 separa o antigo `tpNFCredito=03` (que combinava recusa total + parcial + não localização) em dois códigos: `03` permanece para Recusa Total/Não Localização, e o novo `06` cobre exclusivamente Recusa Parcial na Entrega.
- **Descrição do código `03`** atualizada para "Retorno por Recusa Total na Entrega ou Por Não Localização do Destinatário", refletindo o novo escopo pós-split. **Sem rename do membro** (`RetornoPorRecusaOuNaoLocalizacaoDoDestinatario`) para preservar compatibilidade binária com consumidores existentes.

## Não incluído neste PR

- **`DFeReferenciado` per item já existe** em [`NFe.Classes/Informacoes/Detalhe/DFeReferenciado.cs`](https://github.com/nfe/DFe.NET/blob/master/NFe.Classes/Informacoes/Detalhe/DFeReferenciado.cs) e [`det.cs`](https://github.com/nfe/DFe.NET/blob/master/NFe.Classes/Informacoes/Detalhe/det.cs#L84-L87) (commit `a04a2ee3 ajuste apps para reforma tributaria`). A propriedade `det.DFeReferenciado` (VC01) com `chaveAcesso` (VC02) + `nItem` (VC03) cobre o requisito do Ajuste 8/26 de referenciar item-a-item da NF-e original em `tpNFCredito=06`.

## Compatibilidade

- **Wire format inalterado** para o código 03: `[XmlEnum("03")]` mantido.
- **Sem mudança de assinatura** em qualquer membro existente — só inclusão do novo `RetornoPorRecusaParcial` e atualização de `[Description]` + XML doc.
- **Zero breaking changes** para consumidores atuais.

## Test plan

- [x] `dotnet build NFe.Classes/NFe.Classes.csproj` — 0 erros.
- [ ] Validar serialização: emitir uma NF-e com `tpNFCredito=06` e confirmar que o XML produz `<tpNFCredito>06</tpNFCredito>`.
- [ ] Revalidar contra **XSD oficial 8/26** quando publicado pela SEFAZ (atualmente PEND-eng-02 do consumidor `dfetech-product-invoice-api`). Caso o XSD final tenha discrepâncias na descrição/casing, ajustar este enum.

## Contexto

Este PR desbloqueia a implementação da emissão de Nota de Crédito por Recusa no projeto consumidor [`dfetech-product-invoice-api#66`](https://github.com/nfe/dfetech-product-invoice-api/pull/66) — issue umbrella [`#45`](https://github.com/nfe/dfetech-product-invoice-api/issues/45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)