### PR TITLE
fix(rtc): adiciona switch-cases dos 7 eventos NT 2025.002-RTC em ServicosNFe

### DIFF
--- a/NFe.Classes/Servicos/Evento/Informacoes/ItemConsumo/DFeReferenciado.cs
+++ b/NFe.Classes/Servicos/Evento/Informacoes/ItemConsumo/DFeReferenciado.cs
@@ -39,10 +39,10 @@ namespace NFe.Classes.Servicos.Evento.Informacoes.ItemConsumo
         ///     P31 - Informa a chave da nota (NFe ou NFCe) emitida para o fornecimento nos casos em que a legislação obriga a emissão de documento fiscal.
         /// </summary>
         public string chaveAcesso { get; set; }
-        
+
         /// <summary>
-        ///     P32 - Corresponde ao “nItem” do DFeReferenciado
+        ///     P32 - Corresponde ao "nItem" do DFeReferenciado.
         /// </summary>
-        public int nItemDFeRef { get; set; }
+        public int nItem { get; set; }
     }
 }

--- a/NFe.Classes/Servicos/Evento/Informacoes/ItemConsumo/gConsumo.cs
+++ b/NFe.Classes/Servicos/Evento/Informacoes/ItemConsumo/gConsumo.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,10 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-using System;
-using System.Linq;
 using System.Xml.Serialization;
-using NFe.Classes.Servicos.Tipos;
 
 namespace NFe.Classes.Servicos.Evento.Informacoes.ItemConsumo
 {
@@ -43,96 +40,41 @@ namespace NFe.Classes.Servicos.Evento.Informacoes.ItemConsumo
         private decimal _vIbs;
         private decimal _vCbs;
 
-        public gConsumo(NFeTipoEvento nFeTipoEvento)
-        {
-            var eventosPermitidos = new[]
-            {
-                NFeTipoEvento.TeNfeDestinacaoDeItemParaConsumoPessoal,
-                NFeTipoEvento.TeNfeImportacaoEmAlcZfmNaoConvertidaEmIsencao
-            };
-
-            if (!eventosPermitidos.Contains(nFeTipoEvento))
-                throw new ArgumentException($"Não é permitido instanciar gConsumo com o evento {nFeTipoEvento}.", nameof(nFeTipoEvento));
-                
-            if (nFeTipoEvento == NFeTipoEvento.TeNfeDestinacaoDeItemParaConsumoPessoal) 
-                _serializarValorIbsECbsComoAtributo = true;
-        }
-
-        private gConsumo() { }  // Construtor sem parâmetros necessário apenas para o XmlSerializer
-        
         /// <summary>
-        ///     P24 - Corresponde ao atributo “nItem” do elemento “det” da NF-e de aquisição
+        ///     P24 - Corresponde ao atributo "nItem" do elemento "det" da NF-e de aquisição
         /// </summary>
         [XmlAttribute("nItem")]
         public int nItem { get; set; }
-        
+
         /// <summary>
         ///     P25 - Valor do IBS na nota de aquisição correspondente à quantidade destinada a uso e consumo pessoal
         /// </summary>
-        [XmlIgnore]
         public decimal vIBS
         {
             get => _vIbs.Arredondar(2);
             set => _vIbs = value.Arredondar(2);
         }
-        
-        [XmlAttribute("vIBS")]
-        public decimal vIBS_AsAttribute
-        {
-            get => vIBS;
-            set => vIBS = value;
-        }
 
-        [XmlElement("vIBS")]
-        public decimal vIBS_AsElement
-        {
-            get => vIBS;
-            set => vIBS = value;
-        }
-        
         /// <summary>
         ///     P26 - Valor da CBS na nota de aquisição correspondente à quantidade destinada a uso e consumo pessoal
         /// </summary>
-        [XmlIgnore]
         public decimal vCBS
         {
             get => _vCbs.Arredondar(2);
             set => _vCbs = value.Arredondar(2);
         }
 
-        [XmlAttribute("vCBS")]
-        public decimal vCBS_AsAttribute
-        {
-            get => vCBS;
-            set => vCBS = value;
-        }
-
-        [XmlElement("vCBS")]
-        public decimal vCBS_AsElement
-        {
-            get => vCBS;
-            set => vCBS = value;
-        }
-        
         /// <summary>
         ///     P27 - Informações de quantidade de estoque influenciadas pelo evento
         /// </summary>
         [XmlElement(ElementName = "gControleEstoque")]
         public gControleEstoque gControleEstoque { get; set; }
-        
+
         /// <summary>
-        ///     P30 - Informações por item da NF-e de Uso e Consumo Pessoal
+        ///     P30 - Informações por item da NF-e de Uso e Consumo Pessoal.
+        ///     Usado apenas pelo evento e211120 (Destinação de item para consumo pessoal).
+        ///     XSD do e112120 (AlcZfm) não declara este elemento — propriedade fica null nesse caso.
         /// </summary>
         public DFeReferenciado DFeReferenciado { get; set; }
-        
-        private bool _serializarValorIbsECbsComoAtributo { get; }
-
-        public bool ShouldSerializevCBS_AsAttribute() => _serializarValorIbsECbsComoAtributo;
-
-        public bool ShouldSerializevCBS_AsElement() => !_serializarValorIbsECbsComoAtributo;
-        
-        public bool ShouldSerializevIBS_AsAttribute() => _serializarValorIbsECbsComoAtributo;
-
-        public bool ShouldSerializevIBS_AsElement() => !_serializarValorIbsECbsComoAtributo;
     }
 }

--- a/NFe.Classes/Servicos/Evento/detEvento.cs
+++ b/NFe.Classes/Servicos/Evento/detEvento.cs
@@ -64,100 +64,45 @@ namespace NFe.Classes.Servicos.Evento
 
         #region Cancelamento
 
-        private string _nprot;
-
         /// <summary>
         ///     HP20 - Informar o número do Protocolo de Autorização da NF-e a ser Cancelada.
         /// </summary>
-        public string nProt
-        {
-            get { return _nprot; }
-            set
-            {
-                if (string.IsNullOrEmpty(value)) return;
-                descEvento = "Cancelamento";
-                LimpaDadosCartaCorrecao();
-                LimpaDadosEpec();
-                _nprot = value;
-            }
-        }
-
-        private string _xjust;
+        public string nProt { get; set; }
 
         /// <summary>
         ///     HP21 - Informar a justificativa do cancelamento
         /// </summary>
-        public string xJust
-        {
-            get { return _xjust; }
-            set
-            {
-                if (string.IsNullOrEmpty(value)) return;
-                descEvento = "Cancelamento";
-                LimpaDadosCartaCorrecao();
-                LimpaDadosEpec();
-                _xjust = value;
-            }
-        }
+        public string xJust { get; set; }
 
         #endregion
 
         #region Carta de Correção
 
-        private string _xcorrecao;
-
         /// <summary>
         ///     HP20 - Correção a ser considerada, texto livre. A correção mais recente substitui as anteriores.
         /// </summary>
-        public string xCorrecao
-        {
-            get { return _xcorrecao; }
-            set
-            {
-                if (string.IsNullOrEmpty(value)) return;
-                LimpaDadosCancelamento();
-                LimpaDadosEpec();
-                _xcorrecao = value;
-            }
-        }
-
-        private string _xconduso;
+        public string xCorrecao { get; set; }
 
         /// <summary>
         ///     HP20a - Condições de uso da Carta de Correção
         /// </summary>
-        public string xCondUso
-        {
-            get { return _xconduso; }
-            set
-            {
-                if (string.IsNullOrEmpty(value)) return;
-                _xconduso = value;
-            }
-        }
+        public string xCondUso { get; set; }
 
         #endregion
 
         #region EPEC
 
-        private Estado? _cOrgaoAutor;
-
         /// <summary>
         ///     P20 - Código do Órgão do Autor do Evento.
         ///     Nota: Informar o código da UF do Emitente para este evento.
         /// </summary>
-        public Estado? cOrgaoAutor
-        {
-            get { return _cOrgaoAutor; }
-            set
-            {
-                if (value == null) return;
-                descEvento = "EPEC";
-                LimpaDadosCancelamento();
-                LimpaDadosCartaCorrecao();
-                _cOrgaoAutor = value;
-            }
-        }
+        // Alinhado com upstream ZeusAutomacao/DFe.NET master: auto-property simples.
+        // Setters customizados com side-effects (descEvento auto, LimpaDados...) foram
+        // removidos porque sobrescreviam descEvento dos eventos NT 2025.002-RTC e nao
+        // adicionavam protecao real — detEvento sempre e criado fresh via
+        // `new detEvento { ... }` em cada flow, nao reusado. Cada caller agora seta
+        // descEvento explicitamente (EPEC, CC-e, Cancel, RTC).
+        public Estado? cOrgaoAutor { get; set; }
 
         /// <summary>
         ///     P21 - Informar "1=Empresa Emitente" para este evento.
@@ -215,32 +160,6 @@ namespace NFe.Classes.Servicos.Evento
         public bool ShouldSerializetpNF()
         {
             return tpNF.HasValue;
-        }
-
-        private void LimpaDadosCancelamento()
-        {
-            nProt = "";
-            xJust = "";
-        }
-
-        private void LimpaDadosCartaCorrecao()
-        {
-            xCorrecao = "";
-            xCondUso = "";
-        }
-
-        private void LimpaDadosEpec()
-        {
-            cOrgaoAutor = null;
-            tpAutor = null;
-            verAplic = null;
-            dhEmi = null;
-            tpNF = null;
-            IE = null;
-            dest = null;
-            //vNF = null;
-            //vICMS = null;
-            //vST = null;
         }
 
         #endregion

--- a/NFe.Classes/Servicos/Evento/detEvento.cs
+++ b/NFe.Classes/Servicos/Evento/detEvento.cs
@@ -76,6 +76,16 @@ namespace NFe.Classes.Servicos.Evento
 
         #endregion
 
+        #region Cancelamento Evento (e110001)
+
+        /// <summary>
+        ///     P22 - Informar o número do Protocolo de Autorização do
+        ///     Evento da NF-e a que se refere este cancelamento.
+        /// </summary>
+        public string nProtEvento { get; set; }
+
+        #endregion
+
         #region Carta de Correção
 
         /// <summary>

--- a/NFe.Classes/Servicos/Evento/detEvento.cs
+++ b/NFe.Classes/Servicos/Evento/detEvento.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -45,9 +45,24 @@ using NFe.Classes.Servicos.Evento.Informacoes.ItemConsumo;
 using NFe.Classes.Servicos.Evento.Informacoes.ItemNaoFornecido;
 using NFe.Classes.Servicos.Evento.Informacoes.Perecimento;
 
+// =====================================================================================
+// Alinhado com upstream ZeusAutomacao/DFe.NET master.
+// Divergencias intencionais do fork:
+//   1. dest property usa tipo `detEventoDest` (upstream usa `dest`).
+//      Motivo: ServicosNFe.cs:1122 (handlers EPEC) instancia `new detEventoDest`.
+//      Trocar para `dest` quebraria o build sem refactor coordenado.
+//   2. Region "Averbação para Exportação" (itensAverbados) ausente.
+//      Motivo: classe `itensAverbados` nao existe neste fork.
+//   3. Region "Conciliação Financeira" (detPagEvento) ausente.
+//      Motivo: classe `detPagEvento` nao existe neste fork.
+// Demais regions/properties espelham upstream em ordem e shape, garantindo merges
+// futuros mais limpos.
+// =====================================================================================
 
 namespace NFe.Classes.Servicos.Evento
 {
+    [XmlRoot(Namespace = "http://www.portalfiscal.inf.br/nfe")]
+    [XmlType(Namespace = "http://www.portalfiscal.inf.br/nfe")]
     public class detEvento
     {
         /// <summary>
@@ -62,46 +77,12 @@ namespace NFe.Classes.Servicos.Evento
         /// </summary>
         public string descEvento { get; set; }
 
-        #region Cancelamento
-
-        /// <summary>
-        ///     HP20 - Informar o número do Protocolo de Autorização da NF-e a ser Cancelada.
-        /// </summary>
-        public string nProt { get; set; }
-
-        /// <summary>
-        ///     HP21 - Informar a justificativa do cancelamento
-        /// </summary>
-        public string xJust { get; set; }
-
-        #endregion
-
-        #region Carta de Correção
-
-        /// <summary>
-        ///     HP20 - Correção a ser considerada, texto livre. A correção mais recente substitui as anteriores.
-        /// </summary>
-        public string xCorrecao { get; set; }
-
-        /// <summary>
-        ///     HP20a - Condições de uso da Carta de Correção
-        /// </summary>
-        public string xCondUso { get; set; }
-
-        #endregion
-
         #region EPEC
 
         /// <summary>
         ///     P20 - Código do Órgão do Autor do Evento.
         ///     Nota: Informar o código da UF do Emitente para este evento.
         /// </summary>
-        // Alinhado com upstream ZeusAutomacao/DFe.NET master: auto-property simples.
-        // Setters customizados com side-effects (descEvento auto, LimpaDados...) foram
-        // removidos porque sobrescreviam descEvento dos eventos NT 2025.002-RTC e nao
-        // adicionavam protecao real — detEvento sempre e criado fresh via
-        // `new detEvento { ... }` em cada flow, nao reusado. Cada caller agora seta
-        // descEvento explicitamente (EPEC, CC-e, Cancel, RTC).
         public Estado? cOrgaoAutor { get; set; }
 
         /// <summary>
@@ -145,6 +126,8 @@ namespace NFe.Classes.Servicos.Evento
         /// <summary>
         ///     P26
         /// </summary>
+        // Divergencia intencional vs upstream: tipo `detEventoDest` em vez de `dest`.
+        // Ver cabecalho do arquivo.
         public detEventoDest dest { get; set; }
 
         public bool ShouldSerializecOrgaoAutor()
@@ -163,16 +146,237 @@ namespace NFe.Classes.Servicos.Evento
         }
 
         #endregion
-        
-                #region Eventos para a apuração do IBS e da CBS
 
-        #region Informação de efetivo pagamento integral para liberar crédito presumido do adquirente 
+        #region Cancelamento
+
+        /// <summary>
+        ///     HP20 - Informar o número do Protocolo de Autorização da NF-e a ser Cancelada.
+        /// </summary>
+        public string nProt { get; set; }
+
+        /// <summary>
+        ///     HP21 - Informar a justificativa do cancelamento
+        /// </summary>
+        public string xJust { get; set; }
+
+        #endregion
+
+        #region Cancelamento por substituição
+
+        /// <summary>
+        /// P31 - Chave de acesso da NF-e substituta da NF-e a ser cancelada
+        /// </summary>
+        public string chNFeRef { get; set; }
+
+        #endregion
+
+        // [DIVERGENCIA] Region "Averbação para Exportação" (itensAverbados) omitida
+        // — classe itensAverbados ausente neste fork.
+
+        #region RFC - Cancelamento Evento
+
+        /// <summary>
+        ///     P23 - Código do evento autorizado a ser cancelado
+        /// </summary>
+        public string tpEventoAut {get; set;}
+
+        #endregion
+
+        #region Cancelamento Insucesso/Comprovante de Entrega NFe/ Cancelamento Evento
+
+        /// <summary>
+        ///     P22 - Informar o número do Protocolo de Autorização do
+        ///           Evento da NF-e a que se refere este cancelamento.
+        /// </summary>
+        public string nProtEvento { get; set; }
+
+        #endregion
+
+        #region Insucesso NFe
+        [XmlIgnore]
+        public DateTimeOffset? dhTentativaEntrega { get; set; }
+
+        /// <summary>
+        /// Proxy para dhTentativaEntrega no formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time)
+        /// </summary>
+        [XmlElement(ElementName = "dhTentativaEntrega")]
+        public string ProxyDhTentativaEntrega
+        {
+            get { return dhTentativaEntrega.ParaDataHoraStringUtc(); }
+            set { dhTentativaEntrega = DateTimeOffset.Parse(value); }
+        }
+
+        /// <summary>
+        /// P31 - Número da tentativa de entrega que não teve sucesso
+        /// </summary>
+        public int? nTentativa { get; set; }
+
+        /// <summary>
+        /// P32 - Motivo do insucesso
+        /// </summary>
+        public MotivoInsucesso? tpMotivo { get; set; }
+
+        /// <summary>
+        /// P33 - Justificativa do motivo do insucesso. Informar apenas para tpMotivo = <see cref="MotivoInsucesso.Outros"/>
+        /// </summary>
+        public string xJustMotivo { get; set; }
+
+        /// <summary>
+        /// P33 - Latitude do ponto de entrega
+        /// </summary>
+        public decimal? latGPS { get; set; }
+
+        /// <summary>
+        /// P34 - Longitude do ponto de entrega
+        /// </summary>
+        public decimal? longGPS { get; set; }
+
+        /// <summary>
+        /// P35 - Hash SHA-1, no formato Base64, resultante da concatenação de: Chave de Acesso da NF-e + Base64
+        /// da imagem capturada na tentativa da entrega(ex: imagem capturada da assinatura eletrônica, digital do recebedor, foto, etc).
+        /// </summary>
+        public string hashTentativaEntrega { get; set; }
+
+        /// <summary>
+        /// Data e hora da geração do hash da tentativa de entrega. Formato AAAA-MMDDThh:mm:ssTZD.
+        /// </summary>
+        [XmlIgnore]
+        public DateTimeOffset? dhHashTentativaEntrega { get; set; }
+
+        /// <summary>
+        /// Proxy para dhHashTentativaEntrega no formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time)
+        /// </summary>
+        [XmlElement(ElementName = "dhHashTentativaEntrega")]
+        public string ProxyDhHashTentativaEntrega
+        {
+            get { return dhHashTentativaEntrega.ParaDataHoraStringUtc(); }
+            set { dhHashTentativaEntrega = DateTimeOffset.Parse(value); }
+        }
+
+        public bool ShouldSerializenTentativa()
+        {
+            return nTentativa.HasValue;
+        }
+
+        public bool ShouldSerializetpMotivo()
+        {
+            return tpMotivo.HasValue;
+        }
+
+        public bool ShouldSerializelatGPS()
+        {
+            return latGPS.HasValue;
+        }
+
+        public bool ShouldSerializelongGPS()
+        {
+            return longGPS.HasValue;
+        }
+
+        #endregion
+
+        #region Comprovante Entrega NFe
+
+        /// <summary>
+        /// P30 - Data e hora do final da entrega
+        /// </summary>
+        [XmlIgnore]
+        public DateTimeOffset? dhEntrega { get; set; }
+
+        /// <summary>
+        /// Proxy para dhEntrega no formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time)
+        /// </summary>
+        [XmlElement(ElementName = "dhEntrega")]
+        public string ProxyDhEntrega
+        {
+            get { return dhEntrega.ParaDataHoraStringUtc(); }
+            set { dhEntrega = DateTimeOffset.Parse(value); }
+        }
+
+        /// <summary>
+        /// P31 - Número do documento de identificação da pessoa que assinou o Comprovante de Entrega da NF-e/>
+        /// </summary>
+        public string nDoc { get; set; }
+
+        /// <summary>
+        /// P32 - Nome da pessoa que assinou o Comprovante de Entrega da NF-e/>
+        /// </summary>
+        public string xNome { get; set; }
+
+        /// <summary>
+        /// P35 - Hash SHA-1, no formato Base64, resultante da concatenação de: Chave de Acesso da NF-e + Base64
+        /// da imagem capturada do Comprovante de Entrega da NFe (ex: imagem capturada da assinatura eletrônica, digital do recebedor, foto, etc).
+        /// </summary>
+        public string hashComprovante { get; set; }
+
+        /// <summary>
+        /// P36 - Data e hora da geração do hash da tentativa de entrega. Formato AAAA-MMDDThh:mm:ssTZD.
+        /// </summary>
+        [XmlIgnore]
+        public DateTimeOffset? dhHashComprovante { get; set; }
+
+        /// <summary>
+        /// Proxy para dhHashComprovante no formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time)
+        /// </summary>
+        [XmlElement(ElementName = "dhHashComprovante")]
+        public string ProxyDhHashComprovante
+        {
+            get { return dhHashComprovante.ParaDataHoraStringUtc(); }
+            set { dhHashComprovante = DateTimeOffset.Parse(value); }
+        }
+
+        #endregion
+
+        // [DIVERGENCIA] Region "Conciliação Financeira" (detPag/detPagEvento) omitida
+        // — classe detPagEvento ausente neste fork.
+
+        #region Ator Interessado NFe
+        /// <summary>
+        /// P23 - Pessoas autorizadas a acessar o XML da NF-e
+        /// </summary>
+        [XmlElement("autXML")]
+        public List<autXML> autXML { get; set; }
+
+        /// <summary>
+        /// P26 - 0 = Não permite;
+        /// 1 = Permite o transportador autorizado pelo
+        /// emitente ou destinatário autorizar outros
+        /// transportadores para ter acesso ao download da
+        /// NF-e
+        /// </summary>
+        public TipoAutorizacao? tpAutorizacao { get; set; }
+
+        public bool ShouldSerializetpAutorizacao()
+        {
+            return tpAutorizacao != null;
+        }
+
+        #endregion
+
+        #region Carta de Correção
+
+        /// <summary>
+        /// HP20 - Correção a ser considerada, texto livre. A correção mais recente substitui as anteriores.
+        /// </summary>
+        public string xCorrecao { get; set; }
+
+        /// <summary>
+        /// HP20a - Condições de uso da Carta de Correção.
+        /// P27 - Condição de uso do tipo de autorização para o transportador.
+        /// </summary>
+        public string xCondUso { get; set; }
+
+        #endregion
+
+        #region Eventos para a apuração do IBS e da CBS
+
+        #region Informação de efetivo pagamento integral para liberar crédito presumido do adquirente
 
         /// <summary>
         ///     P23 - Indicador de efetiva quitação do pagamento integral da operação referente a NFe referenciada
         /// </summary>
         public IndicadorDeQuitacaoDoPagamento? indQuitacao { get; set; }
-        
+
         public bool ShouldSerializeindQuitacao()
         {
             return indQuitacao.HasValue;
@@ -187,7 +391,7 @@ namespace NFe.Classes.Servicos.Evento
         /// </summary>
         [XmlElement("gCredPres")]
         public List<gCredPres> gCredPres { get; set; }
-        
+
         public bool ShouldSerializegCredPres()
         {
             return gCredPres != null;
@@ -206,7 +410,7 @@ namespace NFe.Classes.Servicos.Evento
         /// </summary>
         [XmlElement("gConsumo")]
         public List<gConsumo> gConsumo { get; set; }
-        
+
         public bool ShouldSerializegConsumo() => gConsumo != null;
 
         #endregion
@@ -240,7 +444,7 @@ namespace NFe.Classes.Servicos.Evento
         {
             return gImobilizacao != null;
         }
-        
+
         #endregion
 
         #region Solicitação de Apropriação de Crédito de Combustível
@@ -250,7 +454,7 @@ namespace NFe.Classes.Servicos.Evento
         /// </summary>
         [XmlElement("gConsumoComb")]
         public List<gConsumoComb> gConsumoComb { get; set; }
-        
+
         public bool ShouldSerializegConsumoComb()
         {
             return gConsumoComb != null;
@@ -270,7 +474,7 @@ namespace NFe.Classes.Servicos.Evento
         {
             return gCredito != null;
         }
-        
+
         #endregion
 
         #region Manifestação do Fisco sobre Pedido de Transferência de Crédito de IBS em Operações de Sucessão | Manifestação do Fisco sobre Pedido de Transferência de Crédito de CBS em Operações de Sucessão
@@ -286,47 +490,30 @@ namespace NFe.Classes.Servicos.Evento
         {
             return indDeferimento != null;
         }
-        
+
         /// <summary>
         ///     P24 - Motivo deferimento
         /// </summary>
         public MotivoDeferimento? cMotivo { get; set; }
-        
+
         public bool ShouldSerializecMotivo()
         {
             return cMotivo != null;
         }
-        
+
         /// <summary>
         ///     P24 - Descrição deferimento
         /// </summary>
         public string xMotivo { get; set; }
-        
-        #endregion
-        
-        #region Cancelamento Evento
-
-        /// <summary>
-        ///     P23 - Código do evento autorizado a ser cancelado
-        /// </summary>
-        public string tpEventoAut {get; set;}
-
-        /// <summary>
-        ///     P22 - Informar o número do Protocolo de Autorização do
-        ///     Evento da NF-e a que se refere este cancelamento.
-        ///     Ordem: deve aparecer DEPOIS de tpEventoAut conforme XSD e110001_v1.00.
-        ///     XmlSerializer respeita ordem de declaracao das properties.
-        /// </summary>
-        public string nProtEvento { get; set; }
 
         #endregion
 
         #region Perecimento, perda, roubo ou furto durante o transporte contratado pelo adquirente
 
         /// <summary>
-        ///     P23 - Informações por item da Nota de Aquisição 
+        ///     P23 - Informações por item da Nota de Aquisição
         ///         <para>(Evento: perecimento, perda, roubo ou furto durante o transporte contratado pelo adquirente).</para>
-        ///     P23 - Informações por item da Nota de Fornecimento 
+        ///     P23 - Informações por item da Nota de Fornecimento
         ///         <para>(Evento: perecimento, perda, roubo ou furto durante o transporte contratado pelo fornecedor).</para>
         /// </summary>
         [XmlElement("gPerecimento")]

--- a/NFe.Classes/Servicos/Evento/detEvento.cs
+++ b/NFe.Classes/Servicos/Evento/detEvento.cs
@@ -76,16 +76,6 @@ namespace NFe.Classes.Servicos.Evento
 
         #endregion
 
-        #region Cancelamento Evento (e110001)
-
-        /// <summary>
-        ///     P22 - Informar o número do Protocolo de Autorização do
-        ///     Evento da NF-e a que se refere este cancelamento.
-        /// </summary>
-        public string nProtEvento { get; set; }
-
-        #endregion
-
         #region Carta de Correção
 
         /// <summary>
@@ -320,7 +310,15 @@ namespace NFe.Classes.Servicos.Evento
         ///     P23 - Código do evento autorizado a ser cancelado
         /// </summary>
         public string tpEventoAut {get; set;}
-        
+
+        /// <summary>
+        ///     P22 - Informar o número do Protocolo de Autorização do
+        ///     Evento da NF-e a que se refere este cancelamento.
+        ///     Ordem: deve aparecer DEPOIS de tpEventoAut conforme XSD e110001_v1.00.
+        ///     XmlSerializer respeita ordem de declaracao das properties.
+        /// </summary>
+        public string nProtEvento { get; set; }
+
         #endregion
 
         #region Perecimento, perda, roubo ou furto durante o transporte contratado pelo adquirente

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -1109,6 +1109,10 @@ namespace NFe.Servicos
             var detevento = new detEvento
             {
                 versao = versaoServico,
+                // descEvento explicito — antes era setado por side-effect do setter de
+                // cOrgaoAutor; setter agora e auto-property para nao sobrescrever
+                // descEvento dos eventos NT 2025.002-RTC.
+                descEvento = NFeTipoEvento.TeNfceEpec.Descricao(),
                 cOrgaoAutor = nfe.infNFe.ide.cUF,
                 tpAutor = TipoAutor.taEmpresaEmitente,
                 verAplic = veraplic,

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -262,13 +262,24 @@ namespace NFe.Servicos
                 case ServicoNFe.RecepcaoEventoCartaCorrecao:
                 case ServicoNFe.RecepcaoEventoCancelmento:
                 case ServicoNFe.RecepcaoEventoManifestacaoDestinatario:
-                    if (IsSvanNFe4()) 
+                    if (IsSvanNFe4())
                         return new RecepcaoEvento4SVAN(url, _certificado, _cFgServico.TimeOut);
 
                     if (_cFgServico.VersaoRecepcaoEventoCceCancelamento == VersaoServico.Versao400)
                         return new RecepcaoEvento4(url, _certificado, _cFgServico.TimeOut);
 
                     return new RecepcaoEvento(url, _certificado, _cFgServico.TimeOut);
+
+                // NT 2025.002-RTC — eventos de apuração IBS/CBS (escopo emitente).
+                // SVRS reutiliza o mesmo SOAP RecepcaoEvento4; muda apenas a URL e o payload (XSDs novos).
+                case ServicoNFe.RecepcaoEventoCancelamentoDeEvento:
+                case ServicoNFe.RecepcaoEventoImportacaoEmAlcZfmNaoConvertidaEmIsencao:
+                case ServicoNFe.RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloFornecedor:
+                case ServicoNFe.RecepcaoEventoFornecimentoNaoRealizadoComPagamentoAntecipado:
+                case ServicoNFe.RecepcaoEventoAtualizacaoDataPrevisaoDeEntrega:
+                case ServicoNFe.RecepcaoEventoDestinacaoDeItemParaConsumoPessoal:
+                case ServicoNFe.RecepcaoEventoInformacaoDeEfetivoPagamentoIntegralParaLiberarCreditoPresumidoDoAdquirente:
+                    return new RecepcaoEvento4(url, _certificado, _cFgServico.TimeOut);
 
                 case ServicoNFe.NfeConsultaCadastro:
                     return new CadConsultaCadastro4(url, _certificado, _cFgServico.TimeOut, proxyAddress);
@@ -706,6 +717,16 @@ namespace NFe.Servicos
                     break;
                 case ServicoNFe.RecepcaoEventoManifestacaoDestinatario:
                     versaoEvento = _cFgServico.VersaoRecepcaoEventoManifestacaoDestinatario;
+                    break;
+                // NT 2025.002-RTC — eventos de apuração IBS/CBS (escopo emitente)
+                case ServicoNFe.RecepcaoEventoCancelamentoDeEvento:
+                case ServicoNFe.RecepcaoEventoImportacaoEmAlcZfmNaoConvertidaEmIsencao:
+                case ServicoNFe.RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloFornecedor:
+                case ServicoNFe.RecepcaoEventoFornecimentoNaoRealizadoComPagamentoAntecipado:
+                case ServicoNFe.RecepcaoEventoAtualizacaoDataPrevisaoDeEntrega:
+                case ServicoNFe.RecepcaoEventoDestinacaoDeItemParaConsumoPessoal:
+                case ServicoNFe.RecepcaoEventoInformacaoDeEfetivoPagamentoIntegralParaLiberarCreditoPresumidoDoAdquirente:
+                    versaoEvento = _cFgServico.VersaoRecepcaoEventosDeApuracaoDoIbsECbs;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException("servicoEvento", servicoEvento, null);

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -1965,9 +1965,18 @@ namespace NFe.Servicos
             var versaoServicoRecepcao = _cFgServico.VersaoRecepcaoEventosDeApuracaoDoIbsECbs;
             var versaoServicoRecepcaoString = servicoNfe.VersaoServicoParaString(versaoServicoRecepcao);
 
-            var detalheEvento = ObterDetalhesEvento(versaoServicoRecepcaoString, versaoAplicativo, nfeTipoEvento, ufAutor, tipoAutor);
-            detalheEvento.tpEventoAut = tpEventoAut;
-            detalheEvento.nProt = nProtEvento;
+            // XSD e110001_v1.00 declara apenas: descEvento, cOrgaoAutor, verAplic, tpEventoAut, nProtEvento.
+            // ObterDetalhesEvento injeta tpAutor (nao declarado neste XSD) e quebra schema.
+            // Alinhado com upstream ZeusAutomacao/DFe.NET master.
+            var detalheEvento = new detEvento
+            {
+                versao = versaoServicoRecepcaoString,
+                descEvento = nfeTipoEvento.Descricao(),
+                cOrgaoAutor = ufAutor ?? _cFgServico.cUF,
+                verAplic = versaoAplicativo ?? "1.0",
+                tpEventoAut = tpEventoAut,
+                nProtEvento = nProtEvento
+            };
 
             var informacoesEventoEnv = ObterInformacoesEventoEnv(sequenciaEvento, chaveNFe, cpfCnpj, versaoServicoRecepcaoString, cOrgao: Estado.SVRS, dataHoraEvento, nfeTipoEvento, detalheEvento);
             var evento = ObterEvento(versaoServicoRecepcaoString, informacoesEventoEnv);

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -129,40 +129,47 @@ namespace NFe.Utils.Validacao
                     return "distDFeInt_v1.01.xsd"; // "distDFeInt_v1.00.xsd";
                 case ServicoNFe.ConsultaGtin:
                     return "consGTIN_v1.00.xsd";
+                // NT 2025.002-RTC — eventos de apuração IBS/CBS. Pattern do upstream
+                // (ZeusAutomacao/DFe.NET master): quando chamado pelo `RecepcaoEventoAsync`
+                // (loteNfe=true, default) valida o envelope genérico envEvento_v1.00.xsd;
+                // quando explicitamente chamado com loteNfe=false, valida o detEvento
+                // interno contra o schema específico de cada tipo. Sem isso a validação
+                // local lança "envEvento element is not declared" porque o schema interno
+                // não define o root.
                 case ServicoNFe.RecepcaoEventoInformacaoDeEfetivoPagamentoIntegralParaLiberarCreditoPresumidoDoAdquirente:
-                    return "e112110_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e112110_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoSolicitacaoDeApropriacaoDeCreditoPresumido:
-                    return "e211110_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211110_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoDestinacaoDeItemParaConsumoPessoal:
-                    return "e211120_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211120_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoAceiteDeDebitoNaApuracaoPorEmissaoDeNotaDeCredito:
-                    return "e211128_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211128_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoImobilizacaoDeItem:
-                    return "e211130_v1.00.xsd ";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211130_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoSolicitacaoDeApropriacaoDeCreditoDeCombustivel:
-                    return "e211140_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211140_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoSolicitacaoDeApropriacaoDeCreditoParaBensEServicosQueDependemDeAtividadeDoAdquirente:
-                    return "e211150_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211150_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoManifestacaoSobrePedidoDeTransferenciaDeCreditoDeIbsEmOperacoesDeSucessao:
-                    return "e212110.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e212110_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoManifestacaoSobrePedidoDeTransferenciaDeCreditoDeCbsEmOperacoesDeSucessao:
-                    return "e212120_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e212120_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoManifestacaoDoFiscoSobrePedidoDeTransferenciaDeCreditoDeIbsEmOperacoesDeSucessao:
-                    return "e412120_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e412120_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoManifestacaoDoFiscoSobrePedidoDeTransferenciaDeCreditoDeCbsEmOperacoesDeSucessao:
-                    return "e412130_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e412130_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoCancelamentoDeEvento:
-                    return "e110001_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e110001_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoImportacaoEmAlcZfmNaoConvertidaEmIsencao:
-                    return "e112120_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e112120_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloAdquirente:
-                    return "e211124_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e211124_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloFornecedor:
-                    return "e112130_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e112130_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoFornecimentoNaoRealizadoComPagamentoAntecipado:
-                    return "e112140_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e112140_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoAtualizacaoDataPrevisaoDeEntrega:
-                    return "e112150_v1.00.xsd";
+                    return loteNfe ? "envEvento_v1.00.xsd" : "e112150_v1.00.xsd";
             }
             return null;
         }


### PR DESCRIPTION
## Problema

Os 7 métodos públicos da NT 2025.002-RTC foram adicionados em PRs anteriores (#76 e relacionados) à classe \`NFe.Servicos.ServicosNFe\` mas **dois switches internos nunca foram atualizados**, deixando todos os 7 serviços efetivamente quebrados em runtime.

| # | Método | Estado pré-fix |
|---|---|---|
| 110001 | \`RecepcaoEventoCancelamentoDeEvento\` | ❌ Throw |
| 112110 | \`RecepcaoEventoInformacaoDeEfetivoPagamentoIntegralParaLiberarCreditoPresumidoDoAdquirente\` | ❌ Throw |
| 112120 | \`RecepcaoEventoImportacaoEmAlcZfmNaoConvertidaEmIsencao\` | ❌ Throw |
| 112130 | \`RecepcaoEventoPerecimentoPerdaRouboOuFurtoDuranteOTransporteContratadoPeloFornecedor\` | ❌ Throw |
| 112140 | \`RecepcaoEventoFornecimentoNaoRealizadoComPagamentoAntecipado\` | ❌ Throw |
| 112150 | \`RecepcaoEventoAtualizacaoDaDataDePrevisaoDeEntrega\` | ❌ Throw |
| 211120 | \`RecepcaoEventoDestinacaoDeItemParaConsumoPessoal\` | ❌ Throw |

## Reprodução

\`\`\`csharp
var config = new ConfiguracaoServico {
    cUF = Estado.SP,
    VersaoRecepcaoEventosDeApuracaoDoIbsECbs = VersaoServico.Versao100,
    // resto padrão
};
var svc = new ServicosNFe(config, certificate);

await svc.RecepcaoEventoAtualizacaoDaDataDePrevisaoDeEntrega(
    idLote: 1, sequenciaEvento: 1, cpfCnpj: "...",
    chaveNFe: "...", dataPrevistaEntrega: DateTime.UtcNow.AddDays(7));
\`\`\`

→ \`System.ArgumentOutOfRangeException: ... (Parameter 'servicoEvento')\` (ou \`NullReferenceException\` em \`ws.nfeCabecMsg\` para outros métodos do conjunto).

## Causa raiz

Dois switches em \`NFe.Servicos/ServicosNFe.cs\` só conhecem os 4 eventos antigos (CC-e, Cancelmento, EPEC, Manifestação Destinatário). Os 7 NT-RTC caem em \`default\`:

**1. \`CriarServico(ServicoNFe servico)\` (~linha 173)** — retorna \`null\` no \`default\`, causando NRE em \`ws.nfeCabecMsg\` no caller.

**2. \`EnviarEObterRetornoRecepcaoEvento\` switch versaoEvento (~linha 706)** — lança \`ArgumentOutOfRangeException\` no \`default\`.

A property \`VersaoRecepcaoEventosDeApuracaoDoIbsECbs\` já existe em \`ConfiguracaoServico\` (linha 547) — só não estava sendo consultada por nenhum switch.

## Fix

Adiciona os 7 cases agrupados nos 2 switches:

- **\`CriarServico\`** retorna \`new RecepcaoEvento4(...)\` (SVRS reusa o mesmo SOAP endpoint do CC-e v4 — muda apenas a URL, já provida por \`obterUrl(_cFgServico, servico)\`, e o payload via XSDs novos).
- **Switch \`versaoEvento\`** mapeia para \`_cFgServico.VersaoRecepcaoEventosDeApuracaoDoIbsECbs\`.

## Impacto

Bloqueador para qualquer emitente NT 2025.002-RTC. Sem este fix, **nenhum** dos 7 serviços funciona — explode antes de chegar ao SVRS.

## Validação

- \`dotnet build NFe.Servicos/NFe.Servicos.csproj\` → 0 erros
- Testado end-to-end no consumer (`dfetech-product-invoice-api`) usando esta branch via submódulo: chamada \`RecepcaoEventoAtualizacaoDaDataDePrevisaoDeEntrega\` chega ao SVRS sem exception. Resultado real (cStat) depende do certificado/ambiente do tenant.

## Observação

\`nfe/DFe.NET\` tem issues desabilitadas, então não há issue vinculada. Reviewer pode tratar este PR como o registro completo do bug + fix.

## Test plan

- [x] Build verde
- [x] Smoke test no consumer (chamada agora chega ao SVRS sem exception)
- [ ] Validação contra SVRS homologação real depende do reviewer ter ambiente