### PR TITLE
fix(legacy): popular descEvento em RecepcaoEventoCancelamentoAsync (alinhado com upstream)

### DIFF
--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -929,10 +929,34 @@ namespace NFe.Servicos
         /// <param name="chaveNFe"></param>
         /// <param name="justificativa"></param>
         /// <param name="cpfcnpj"></param>
-        /// <returns>Retorna um objeto da classe RetornoRecepcaoEvento com o retorno do serviço RecepcaoEvento</returns>
+        /// <returns>Retorna um objeto da classe <see cref="RetornoRecepcaoEvento"/> com o retorno do serviço <see cref="RecepcaoEvento"/></returns>
         public Task<RetornoRecepcaoEvento> RecepcaoEventoCancelamentoAsync(long idlote, int sequenciaEvento,
             string protocoloAutorizacao, string chaveNFe, string justificativa, string cpfcnpj)
         {
+            return RecepcaoEventoCancelamentoAsync(NFeTipoEvento.TeNfeCancelamento, idlote, sequenciaEvento,
+                protocoloAutorizacao, chaveNFe, justificativa, cpfcnpj);
+        }
+
+        /// <summary>
+        ///     Envia um evento do tipo "Cancelamento por substituição"
+        /// </summary>
+        /// <returns>Retorna um objeto da classe <see cref="RetornoRecepcaoEvento"/> com o retorno do serviço <see cref="RecepcaoEvento"/></returns>
+        public Task<RetornoRecepcaoEvento> RecepcaoEventoCancelamentoPorSubstituicaoAsync(long idlote, int sequenciaEvento,
+            string protocoloAutorizacao, string chaveNFe, string justificativa, string cpfcnpj, Estado ufAutor, string versaoAplicativo, string chaveNfeSubstituta)
+        {
+            return RecepcaoEventoCancelamentoAsync(NFeTipoEvento.TeNfeCancelamentoSubstituicao, idlote, sequenciaEvento,
+                protocoloAutorizacao, chaveNFe, justificativa, cpfcnpj, ufAutor, TipoAutor.taEmpresaEmitente, versaoAplicativo, chaveNfeSubstituta);
+        }
+
+        private Task<RetornoRecepcaoEvento> RecepcaoEventoCancelamentoAsync(NFeTipoEvento tipoEventoCancelamento, long idlote,
+            int sequenciaEvento, string protocoloAutorizacao, string chaveNFe, string justificativa, string cpfcnpj,
+            Estado? ufAutor = null, TipoAutor? tipoAutor = null, string versaoAplicativo = null, string chaveNfeSubstituta = null)
+        {
+            if (!NFeTipoEventoUtils.NFeTipoEventoCancelamento.Contains(tipoEventoCancelamento))
+                throw new Exception(string.Format("Informe um dos seguintes tipos de eventos: {0}",
+                    string.Join(", ",
+                        NFeTipoEventoUtils.NFeTipoEventoCancelamento.Select(n => n.Descricao()))));
+
             var versaoServico =
                 ServicoNFe.RecepcaoEventoCancelmento.VersaoServicoParaString(
                     _cFgServico.VersaoRecepcaoEventoCceCancelamento);
@@ -941,36 +965,32 @@ namespace NFe.Servicos
             {
                 nProt = protocoloAutorizacao,
                 versao = versaoServico,
-                xJust = justificativa
+                xJust = justificativa,
+                descEvento = tipoEventoCancelamento.Descricao(),
+                cOrgaoAutor = ufAutor,
+                tpAutor = tipoAutor,
+                verAplic = versaoAplicativo,
+                chNFeRef = chaveNfeSubstituta
             };
-
             var infEvento = new infEventoEnv
             {
                 cOrgao = _cFgServico.cUF,
                 tpAmb = _cFgServico.tpAmb,
                 chNFe = chaveNFe,
                 dhEvento = DateTime.Now,
-                tpEvento = NFeTipoEvento.TeNfeCancelamento,
+                tpEvento = tipoEventoCancelamento,
                 nSeqEvento = sequenciaEvento,
                 verEvento = versaoServico,
                 detEvento = detEvento
             };
-
             if (cpfcnpj.Length == 11)
                 infEvento.CPF = cpfcnpj;
             else
                 infEvento.CNPJ = cpfcnpj;
 
-            var evento = new evento
-            {
-                versao = versaoServico,
-                infEvento = infEvento
-            };
+            var evento = new evento { versao = versaoServico, infEvento = infEvento };
 
-            return RecepcaoEventoEAssinaAsync(idlote, new List<evento>
-            {
-                evento
-            }, ServicoNFe.RecepcaoEventoCancelmento);
+            return RecepcaoEventoEAssinaAsync(idlote, new List<evento> { evento }, ServicoNFe.RecepcaoEventoCancelmento);
         }
 
         /// <summary>


### PR DESCRIPTION
## Contexto

O fork mantém o método `RecepcaoEventoCancelamentoAsync` com a signature original (assíncrona, `long idlote`). Antes, ele construía o `detEvento` sem `descEvento` — funcionava por side-effect do setter de `nProt` em `detEvento.cs`. O setter foi removido no PR #78 deste fork ao alinhar `detEvento.cs` com upstream `ZeusAutomacao/DFe.NET` master.

## Sintoma

SEFAZ rejeita o evento de cancelamento (110111) com:

```
cStat: 493
xMotivo: Rejeição: Evento não atende o Schema XML específico
         (Elemento: envEvento/evento[1]/infEvento/detEvento/nProt)
```

`descEvento` é o primeiro elemento da sequence no XSD `e110111_v1.00.xsd`. Sem ele, o validador encontra `nProt` na primeira posição e falha.

## Fix — refactor estrutural alinhando com upstream

Em vez de simplesmente adicionar `descEvento = "Cancelamento"` no público, replico a estrutura do upstream master:

1. **Public `RecepcaoEventoCancelamentoAsync`** → delegator que hardcoda `NFeTipoEvento.TeNfeCancelamento`
2. **Public `RecepcaoEventoCancelamentoPorSubstituicaoAsync`** (NOVO) → suporte a NFe cancelamento por substituição (quando aplicável)
3. **Private `RecepcaoEventoCancelamentoAsync(NFeTipoEvento, ...)`** → implementação compartilhada, body **byte-a-byte idêntico** ao upstream master (linhas 627-672 de `ServicosNFe.cs`)

A motivação é manter a method body alinhada com upstream pra que diffs futuros não acusem divergência semântica desta linha. A única divergência inerente é o sufixo `Async` + tipo de retorno `Task<>` + helper `RecepcaoEventoEAssinaAsync` (vs upstream sync `RecepcaoEvento`) — pre-existente do fork, não introduzida aqui.

## Diff vs upstream master para o body

```csharp
// fork (após este PR)
var detEvento = new detEvento
{
    nProt = protocoloAutorizacao,
    versao = versaoServico,
    xJust = justificativa,
    descEvento = tipoEventoCancelamento.Descricao(),
    cOrgaoAutor = ufAutor,
    tpAutor = tipoAutor,
    verAplic = versaoAplicativo,
    chNFeRef = chaveNfeSubstituta
};
```

— **idêntico ao upstream**.

## Test plan

- [x] Build: `dotnet build NFe.Servicos/NFe.Servicos.csproj` — 0 erros
- [ ] App consumidor da method (`nfeio-product-invoice`) consegue cancelar NFe em homologação sem cStat 493 (via `CreateEventToCancel` legado, não via essa method, mas validação cruzada do schema)
- [ ] Diff do body desta method vs upstream master → vazio (modulo `Task<>` async wrapping)

## Notas

- Apps que constroem o `detEvento` manualmente (ex: `nfeio-product-invoice` via `CreateEventToCancel` em `GatewayService.cs`) podem continuar fazendo seu próprio fix em código do app — este PR não afeta.
- `RecepcaoEventoCartaCorrecaoAsync` e `RecepcaoEventoEpecAsync` já populavam `descEvento` explicitamente.
- `RecepcaoEventoCancelamentoPorSubstituicaoAsync` é nova — adicionada pra simetria com upstream, mesmo que ainda não tenha call-site neste fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)