### PR TITLE
feat(nuget): habilitar publicação dos 6 projetos netstandard como pacotes NuGet

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -72,9 +72,21 @@ jobs:
       - name: List artifacts
         run: ls -la ./artifacts
 
-      - name: Push to GitHub Packages
+      - name: Push packages (.nupkg) to GitHub Packages
         run: |
           dotnet nuget push './artifacts/*.nupkg' \
+            --source https://nuget.pkg.github.com/nfe/index.json \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --skip-duplicate
+
+      # Symbol packages (.snupkg) precisam de push separado — o glob *.nupkg
+      # acima não os captura, e o Directory.Build.props declara IncludeSymbols
+      # com SymbolPackageFormat=snupkg. Sem este passo os consumidores não
+      # conseguem PDBs nem SourceLink (debugging quebrado). GitHub Packages
+      # suporta .snupkg desde 2020.
+      - name: Push symbol packages (.snupkg) to GitHub Packages
+        run: |
+          dotnet nuget push './artifacts/*.snupkg' \
             --source https://nuget.pkg.github.com/nfe/index.json \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,87 @@
+name: Publish NuGet
+
+# Empacota e publica os 6 projetos NFe/DFe netstandard como pacotes NuGet
+# em GitHub Packages (feed da org nfe).
+#
+# Triggers:
+#   - push de tag v*    → release versionada (pega a versão da tag)
+#   - workflow_dispatch → execução manual para testes (versão informada
+#                         como input ou fallback 0.0.0-manual.{run_number})
+#
+# Pré-requisitos no consumidor:
+#   1. nuget.config com source apontando para https://nuget.pkg.github.com/nfe/index.json
+#   2. PAT com escopo read:packages adicionado como secret/login NuGet
+#
+# Pacotes publicados: NFEio.DFe.Classes, NFEio.DFe.Utils, NFEio.NFe.Classes,
+# NFEio.NFe.Servicos, NFEio.NFe.Utils, NFEio.NFe.Wsdl.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Versão a publicar (ex: 1.0.0-rc.1). Vazio = 0.0.0-manual.{run_number}'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  pack-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # tag refs/tags/vX.Y.Z → X.Y.Z
+            VERSION="${GITHUB_REF_NAME#v}"
+          elif [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="0.0.0-manual.${{ github.run_number }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Pack projects
+        run: |
+          for proj in DFe.Classes DFe.Utils NFe.Classes NFe.Servicos NFe.Utils NFe.Wsdl; do
+            echo "::group::Pack $proj"
+            dotnet pack "$proj/$proj.csproj" \
+              --configuration Release \
+              --output ./artifacts \
+              -p:Version=${{ steps.version.outputs.version }}
+            echo "::endgroup::"
+          done
+
+      - name: List artifacts
+        run: ls -la ./artifacts
+
+      - name: Push to GitHub Packages
+        run: |
+          dotnet nuget push './artifacts/*.nupkg' \
+            --source https://nuget.pkg.github.com/nfe/index.json \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
+            --skip-duplicate
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages-${{ steps.version.outputs.version }}
+          path: ./artifacts/*.*nupkg
+          retention-days: 30

--- a/DFe.Classes/DFe.Classes.csproj
+++ b/DFe.Classes/DFe.Classes.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>DFe.Classes</RootNamespace>
     <AssemblyName>DFe.Classes</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageId>NFEio.DFe.Classes</PackageId>
+    <Description>Classes compartilhadas entre os projetos DFe (NFe, NFCe, CTe, MDFe) do fork NFE.io de Zeus.Net.NFe.NFCe. Inclui tipos básicos, entidades de domínio e flags.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DFe.Utils/DFe.Utils.csproj
+++ b/DFe.Utils/DFe.Utils.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>DFe.Utils</RootNamespace>
     <AssemblyName>DFe.Utils</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageId>NFEio.DFe.Utils</PackageId>
+    <Description>Utilitários compartilhados entre os projetos DFe (NFe, NFCe, CTe, MDFe) do fork NFE.io de Zeus.Net.NFe.NFCe. Inclui assinatura digital, extensões de tipos e helpers de serialização XML.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,41 @@
+<Project>
+
+  <!--
+    Propriedades comuns dos pacotes NuGet publicados pelo fork nfe/DFe.NET.
+
+    Cada projeto packável (DFe.Classes, DFe.Utils, NFe.Classes, NFe.Servicos,
+    NFe.Utils, NFe.Wsdl) sobrescreve <PackageId> e <Description>. Os demais
+    metadados (autoria, licença, URLs, símbolos) vivem aqui para evitar
+    drift entre os 6 csproj.
+
+    Versionamento: <Version> é injetada pela pipeline CI (.github/workflows/
+    nuget-publish.yml) extraindo de tags `v*`. Fallback `1.0.0-local` permite
+    `dotnet pack` rodar localmente para testes sem CI.
+  -->
+  <PropertyGroup>
+    <Version Condition="'$(Version)' == ''">1.0.0-local</Version>
+    <Authors>NFE.io</Authors>
+    <Company>NFE.io</Company>
+    <Copyright>Copyright (c) NFE.io e contribuidores Zeus (Zeusdev Tecnologia LTDA)</Copyright>
+    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/nfe/DFe.NET</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/nfe/DFe.NET</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>nfe;nfce;sefaz;dfe;rtc;reforma-tributaria;nfeio</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <!--
+    README.md da raiz do repo incluído em todos os pacotes (mesma fonte).
+    Necessário porque o NuGet 5.10+ exige PackageReadmeFile referenciando
+    arquivo do próprio diretório do projeto OU explicitamente Pack=true.
+  -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/NFe.Classes/NFe.Classes.csproj
+++ b/NFe.Classes/NFe.Classes.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>NFe.Classes</RootNamespace>
     <AssemblyName>NFe.Classes</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageId>NFEio.NFe.Classes</PackageId>
+    <Description>Classes de domínio para Nota Fiscal Eletrônica (NFe) e Nota Fiscal de Consumidor Eletrônica (NFCe) — fork NFE.io de Zeus.Net.NFe.NFCe. Inclui leiaute completo NFe v4.00, eventos da NT 2025.002-RTC (211110-150, 212110-120, 412120-130, 110001), tipos do IBS/CBS/IS, e classes de DistribuicaoDFe.</Description>
   </PropertyGroup>
   <ItemGroup>
     <None Include="NFe.Classes.licenseheader" />

--- a/NFe.Servicos/NFe.Servicos.csproj
+++ b/NFe.Servicos/NFe.Servicos.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>NFe.Servicos</RootNamespace>
     <AssemblyName>NFe.Servicos</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageId>NFEio.NFe.Servicos</PackageId>
+    <Description>Camada de serviços para invocar webservices SEFAZ da NFe/NFCe — fork NFE.io de Zeus.Net.NFe.NFCe. Expõe ServicosNFe com métodos RecepcaoEvento para os 17 eventos da NT 2025.002-RTC (Crédito Presumido, Imobilização, Consumo Pessoal, Manifestações IBS/CBS de Sucessão, etc.), além dos eventos legacy (Manifestação Destinatário 21020X, Carta de Correção, Cancelamento).</Description>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DFe.Classes\DFe.Classes.csproj" />

--- a/NFe.Utils/NFe.Utils.csproj
+++ b/NFe.Utils/NFe.Utils.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>NFe.Utils</RootNamespace>
     <AssemblyName>NFe.Utils</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageId>NFEio.NFe.Utils</PackageId>
+    <Description>Utilitários para o leiaute da NFe/NFCe — fork NFE.io de Zeus.Net.NFe.NFCe. Inclui Validador (com mappings XSD da NT 2025.002-RTC), Enderecador (URLs SVRS prod/hom), assinatura digital, conversões de tipos e extensões.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NFe.Wsdl/NFe.Wsdl.csproj
+++ b/NFe.Wsdl/NFe.Wsdl.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>NFe.Wsdl</RootNamespace>
     <AssemblyName>NFe.Wsdl</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageId>NFEio.NFe.Wsdl</PackageId>
+    <Description>Contratos WSDL e clientes SOAP para os webservices da NFe/NFCe — fork NFE.io de Zeus.Net.NFe.NFCe. Cobre NfeAutorizacao4, NfeRetAutorizacao4, NfeStatusServico4, NfeConsultaProtocolo4, NfeConsultaCadastro4, NFeRecepcaoEvento4, NFeInutilizacao4, NFeDistribuicaoDFe e variantes estaduais.</Description>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DFe.Classes\DFe.Classes.csproj" />


### PR DESCRIPTION
> Sub-issue Fase 1 do épico **nfe/dfetech-distribution-api#137** — rastreada por nfe/dfetech-distribution-api#138.

## Sumário

Empacota os 6 projetos netstandard já existentes do fork (`DFe.Classes`, `DFe.Utils`, `NFe.Classes`, `NFe.Servicos`, `NFe.Utils`, `NFe.Wsdl`) como pacotes NuGet publicados no **GitHub Packages** (feed da org `nfe`). Habilita a Fase 2+3 (nfe/dfetech-distribution-api#139), onde os consumidores vão remover `libs/DFe.NET/` embedded e usar `PackageReference` aos pacotes desta PR.

## Descoberta da fase de investigação

A sub-issue #138 partiu da premissa de que o fork precisaria de projetos `.Standard.csproj` adicionais (transplantados do `libs/DFe.NET/` embedded). **Não precisa**: o fork já tem 6 csproj netstandard prontos. A migração para netstandard foi feita pelo upstream Zeus em commits anteriores, fazendo a Fase 1 muito mais simples:

| Projeto | TargetFramework | Status |
|---------|----------------|--------|
| `DFe.Classes` | `netstandard1.3` | ✅ Pronto |
| `DFe.Utils` | `netstandard2.0` | ✅ Pronto |
| `NFe.Classes` | `netstandard2.0` | ✅ Pronto |
| `NFe.Servicos` | `netstandard2.0` | ✅ Pronto |
| `NFe.Utils` | `netstandard2.0` | ✅ Pronto |
| `NFe.Wsdl` | `netstandard2.0` | ✅ Pronto |

Não há `#if NETSTANDARD` em nenhum arquivo `.cs` dos 6 — o código já é compatível por padrão.

`CTe.*` continua em `v4.6.1` (Framework). Não cabe nesta PR — pode virar sub-issue separada se a empacotagem do CTe for necessária.

## Mudanças

### `Directory.Build.props` (novo, raiz)
Metadados NuGet compartilhados entre os 6 projetos:
- Authors = `NFE.io`
- Licença = `LGPL-2.1-or-later` (mesma do upstream Zeus)
- `RepositoryUrl`, `ProjectUrl` apontando para este fork
- `IncludeSymbols=true` + `SymbolPackageFormat=snupkg` para debug remoto
- `PackageReadmeFile` referenciando `README.md` da raiz (mesmo arquivo em todos os pacotes)
- `EmbedUntrackedSources=true` para SourceLink
- `Version` default `1.0.0-local` para builds locais; pipeline sobrescreve via `-p:Version=`

### `.csproj` de cada projeto packável
Adicionado `<PackageId>` e `<Description>` em cada um. Prefixo `NFEio.*` evita colisão com nomes do upstream Zeus caso ambos sejam referenciados num mesmo consumidor durante a migração gradual:

| `.csproj` | PackageId |
|-----------|-----------|
| `DFe.Classes/DFe.Classes.csproj` | `NFEio.DFe.Classes` |
| `DFe.Utils/DFe.Utils.csproj` | `NFEio.DFe.Utils` |
| `NFe.Classes/NFe.Classes.csproj` | `NFEio.NFe.Classes` |
| `NFe.Servicos/NFe.Servicos.csproj` | `NFEio.NFe.Servicos` |
| `NFe.Utils/NFe.Utils.csproj` | `NFEio.NFe.Utils` |
| `NFe.Wsdl/NFe.Wsdl.csproj` | `NFEio.NFe.Wsdl` |

### `.github/workflows/nuget-publish.yml` (novo)
Workflow CI que dispara em:
- **push de tags `v*`** — release versionada, extrai versão da tag (`refs/tags/v1.0.0` → `1.0.0`)
- **`workflow_dispatch`** — execução manual com input opcional de versão, fallback `0.0.0-manual.{run_number}`

Etapas:
1. Setup .NET 8 SDK
2. Resolve versão
3. `dotnet pack` dos 6 projetos para `./artifacts/`
4. `dotnet nuget push` para `https://nuget.pkg.github.com/nfe/index.json` com auth via `GITHUB_TOKEN`
5. Upload de artifacts no GitHub Actions (retenção 30 dias)

`--skip-duplicate` permite re-publicar mesma versão sem falha (útil para retries).

## Smoke test local

Validado `dotnet pack` dos 6 projetos com `-p:Version=1.0.0-smoke`:

```
NFEio.DFe.Classes.1.0.0-smoke.nupkg + .snupkg
NFEio.DFe.Utils.1.0.0-smoke.nupkg + .snupkg
NFEio.NFe.Classes.1.0.0-smoke.nupkg + .snupkg
NFEio.NFe.Servicos.1.0.0-smoke.nupkg + .snupkg
NFEio.NFe.Utils.1.0.0-smoke.nupkg + .snupkg
NFEio.NFe.Wsdl.1.0.0-smoke.nupkg + .snupkg
```

Conferido `.nuspec` de `NFEio.NFe.Servicos`: dependências corretas para os 5 pacotes auxiliares no group `.NETStandard2.0`, metadados todos preenchidos (license, projectUrl, repository com commit SHA via SourceLink, README, tags).

## Como rodar pós-merge

**Local (sem publicar):**
```bash
dotnet pack DFe.Classes/DFe.Classes.csproj -c Release -o ./artifacts -p:Version=1.0.0-test
```

**CI release:**
```bash
git tag v1.0.0
git push origin v1.0.0
# workflow dispara automaticamente, publica em GitHub Packages
```

**CI manual:**
GitHub Actions → Publish NuGet → Run workflow → input `version=1.0.0-rc.1`

## Test plan

- [x] `dotnet pack` dos 6 projetos local (`1.0.0-smoke`)
- [x] `.nuspec` validado com dependências corretas
- [x] Build limpo (warnings pré-existentes só de vulnerabilidade conhecida em `System.Security.Cryptography.Xml 4.4.0`, não introduzida aqui)
- [ ] **Pós-merge**: criar tag `v1.0.0` no fork, workflow publica pacotes, smoke test em projeto consumidor isolado instalando `NFEio.NFe.Servicos`
- [ ] **Pós-publicação**: prosseguir para nfe/dfetech-distribution-api#139 (Fase 2+3)

## Bloqueia

- nfe/dfetech-distribution-api#139 — pacotes precisam estar publicados antes da migração dos consumidores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)