### PR TITLE
docs(readme): pivot para Zeus.Net oficial; manter fork como referencia historica

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+> ## ⚠️ Status deste fork (nfe/DFe.NET)
+>
+> Este fork existia para complementar o upstream [ZeusAutomacao/DFe.NET](https://github.com/ZeusAutomacao/DFe.NET) enquanto o suporte aos eventos NT 2025.002-RTC e ao targeting netstandard ainda não estava no upstream.
+>
+> **Em 2026-05-26, o `dfetech-distribution-api` migrou para os pacotes oficiais do upstream:**
+> - [`Zeus.Net.NFe.NFCe`](https://www.nuget.org/packages/Zeus.Net.NFe.NFCe/)
+> - [`Zeus.Net.CTe`](https://www.nuget.org/packages/Zeus.Net.CTe/)
+>
+> O upstream já publica `netstandard2.0` + `net6.0` multi-target, cobrindo o caso de uso do consumer interno. Manter este fork + pipeline próprio se tornou desnecessário.
+>
+> **Prefira o upstream para novos consumidores.** Este fork permanece como referência histórica e contém:
+> - Commits do ciclo NT 2025.002-RTC anterior ao merge no upstream (PRs #76–#80)
+> - PR #81 (NuGet pipeline próprio) fechado sem merge — superado pelo pivot
+>
+> Migração documentada em [nfe/dfetech-distribution-api#143](https://github.com/nfe/dfetech-distribution-api/pull/143).
+
+---
+
 [![Build status](https://ci.appveyor.com/api/projects/status/7igb6s48sw2p95o3/branch/master?svg=true)](https://ci.appveyor.com/project/adeniltonbs/zeus-net-nfe-nfce/branch/master) 
 [![Issues](https://img.shields.io/github/issues/ZeusAutomacao/DFe.NET.svg?style=flat-square)](https://github.com/ZeusAutomacao/DFe.NET/issues)
 


### PR DESCRIPTION
## Summary

Adiciona nota no topo do README sinalizando que este fork foi superado pelos pacotes oficiais `Zeus.Net.NFe.NFCe` + `Zeus.Net.CTe` do upstream [ZeusAutomacao/DFe.NET](https://github.com/ZeusAutomacao/DFe.NET).

## Contexto

Em 2026-05-26 o consumer interno (`dfetech-distribution-api`) migrou de `libs/DFe.NET` embedded para os pacotes oficiais do upstream, que já publicam `netstandard2.0` + `net6.0` multi-target.

Como resultado:
- PR #81 (NuGet pipeline próprio) foi fechado sem merge
- Issues de planejamento da migração no consumer (#137–#142) foram fechadas com nota de pivot
- Este fork permanece como referência histórica dos commits NT 2025.002-RTC (#76–#80) anteriores ao merge no upstream

## Conteúdo do diff

- `README.md` ganha bloco em destaque no topo explicando o status do fork e linkando o PR de migração: nfe/dfetech-distribution-api#143

## Test plan

- [x] Renderização do markdown verificada localmente
- [x] Links para o upstream e para o PR consumer testados

🤖 Generated with [Claude Code](https://claude.com/claude-code)